### PR TITLE
docs(metodologia): CLAUDE.md + CONTEXT-PACK + STATE para el workstream v3 [F0]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+---
+
+## Qué es traz-prod-assetplanner
+
+**AssetPlanner** es la aplicación de mantenimiento industrial de Trazalog: gestión de equipos, órdenes de trabajo, solicitudes de servicio, planes preventivos/predictivos, backlog y KPIs. Corre **en producción** como app standalone (login propio, sin DNato) para clientes reales del sector minero/industrial de San Juan.
+
+Está en curso su **integración con traz-tools v3** en dos frentes:
+1. **Corto plazo** (requerimiento activo): asset deja de usar su propio almacén y herramientas, y consume los módulos de traz-tools (`traz-comp-almacenes`/`ALMDataService`, `traz-comp-pan`/`PANDataservice`) vía REST.
+2. **Mediano plazo**: migración del núcleo completo como submódulo `traz-tools-man` de traz-tools. El plan vive en `traz-tools/doc/migracion/assetplanner-a-traz-tools-man.md`.
+
+---
+
+## Stack técnico
+
+- **Frontend**: PHP / CodeIgniter 3.1.5 (NO HMVC — controllers/models/views clásicos bajo `application/`)
+- **Base de datos**: MariaDB `assetv2` — **esquema CONGELADO** mientras dure la migración a tools (ver Restricciones)
+- **Integración**: `application/libraries/REST.php` (cURL wrapper) contra WSO2
+- **BPM**: Bonita — **la MISMA instancia que usa traz-tools** (decisión 2026-08-12)
+- **Front**: jQuery 2.1.4, jQuery UI, AdminLTE, FullCalendar 2.2.5, DataTables
+
+## Estructura del repo
+
+```
+/
+├── application/
+│   ├── controllers/        — 66 controllers CI3 clásicos
+│   ├── models/             — 67 models (SQL directo vía $this->db)
+│   ├── views/              — 77 dirs de vistas
+│   ├── libraries/          — REST.php, BPM.php, Multi_menu.php, koolreport
+│   └── config/             — constants.php, database.php
+├── api/                    — Artefactos WSO2 propios (⚠️ derivados de traz-tools, ver Restricciones)
+├── _backend/api/           — Ídem
+├── database/               — Dumps y scripts históricos (referencia, NO fuente de verdad del esquema)
+└── doc/v3/                 — CONTEXT-PACK.md y STATE.md de la integración v3 (este workstream)
+```
+
+---
+
+## 🔒 Metodología de Git — OBLIGATORIA
+
+### Modelo de ramas
+
+| Rama | Propósito |
+|---|---|
+| `master` | Producción — recibe merges de `develop` vía tags `v2.9.x` (flujo v2 existente, NO tocar) |
+| `develop` | Soporte v2 en producción — bugfixes de clientes actuales (flujo de Pablo Marrelli) |
+| `develop-v3` | **Integración con tools v3** — rama base para TODO el trabajo de integración/migración |
+| `<tipo>/<id>-<desc>` | Ramas de trabajo — PR a `develop-v3` (v3) o `develop` (soporte v2) |
+
+### Reglas
+
+1. PROHIBIDO commit o push directo a `master`, `develop` y `develop-v3`. Todo entra por Pull Request.
+2. Trabajo v3: `git checkout develop-v3 && git pull`, crear `<tipo>/<fase>-<desc>` (tipos: feat, fix, docs, chore, refactor).
+3. **Un PR por fase del plan** (ver `doc/v3/STATE.md`): cada fase F0…F6 tiene al menos su propio PR contra `develop-v3`, nunca una mega-rama con todo.
+4. Formato de commit: `tipo(scope): descripción [FASE]` — ej. `feat(alm): models de almacén via REST a ALMDataService [F3]`.
+5. NO mergear PRs sin confirmación explícita de Rodolfo.
+6. El flujo v2 (`pmarrelli` → `develop` → `master` + tags) sigue intacto y no es asunto de este workstream. No sincronizar `develop` → `develop-v3` a mano sin coordinarlo.
+7. Antes de un PR: verificar sintaxis (`php -l` sobre lo tocado), cero marcadores de conflicto, cero secretos nuevos (este repo ya tiene credenciales legacy commiteadas — no agregar más).
+
+### Formato obligatorio de descripción de PR
+
+```markdown
+## Qué cambia
+[1-2 líneas, en términos funcionales]
+
+## Por qué
+[fase del plan / decisión que lo origina]
+
+## Cómo lo verifiqué
+[php -l / pruebas manuales / curls contra el DEV, con resultado]
+```
+
+---
+
+## 🧭 Metodología de trabajo — antes y después de cada tarea
+
+> Adaptación de la metodología de `traz-tools` (CICD_STRATEGY §5-bis) a este repo. La fuente canónica del proceso es ese documento; esto es el resumen operativo local.
+
+### Antes de empezar CUALQUIER tarea
+
+1. Leé `doc/v3/CONTEXT-PACK.md` completo (resumen operativo local).
+2. Leé `doc/v3/STATE.md` para saber en qué fase está el workstream y qué quedó pendiente.
+3. **Chequeo de staleness:** el CONTEXT-PACK local declara contra qué versión del CONTEXT-PACK de `traz-tools` y de qué fecha del plan de migración fue escrito. Si `traz-tools/doc/v3/CONTEXT-PACK.md` tiene versión más nueva, o `doc/migracion/assetplanner-a-traz-tools-man.md` cambió después, PARÁ y reportá la desincronización antes de continuar.
+
+### Jerarquía de fuentes
+
+1. **Plan y decisiones de la integración** → `traz-tools/doc/migracion/assetplanner-a-traz-tools-man.md` + la tabla de decisiones del CONTEXT-PACK local.
+2. **Arquitectura de identidad y datos** → `traz-tools/doc/v3/TRAZALOG_v3_MCP_ARCHITECTURE.md` + `traz-tools/doc/adr/`.
+3. **Proceso** → `traz-tools/doc/v3/TRAZALOG_v3_CICD_STRATEGY.md` §5-bis.
+
+Ante ambigüedad o tema no cubierto: PARÁ. No improvises decisiones de arquitectura — las toma Rodolfo (con workshop previo si es clase 🔴).
+
+### Al terminar CUALQUIER tarea (Definition of Done)
+
+1. Actualizá `doc/v3/STATE.md`: fase/tarea a su estado final, "próxima acción", decisión nueva si la hubo.
+2. Si la tarea cambió una decisión de la tabla del CONTEXT-PACK local: actualizalo en el MISMO PR, con bump de versión.
+3. Abrí el PR con el formato obligatorio.
+4. Si la tarea tocó algo que el plan de migración de `traz-tools` da por cierto (inventarios, supuestos, riesgos): anotá en la descripción del PR que ese doc necesita update, para hacerlo en el repo de tools.
+
+### Reglas de escalamiento
+
+| Tipo de duda | Qué hacés |
+|---|---|
+| Técnica menor (dos formas válidas de implementar) | Decidís vos, lo documentás en el PR |
+| Funcional o de negocio (afecta a clientes en producción, datos, o el modelo comercial) | PARÁS y preguntás a Rodolfo con opciones + recomendación |
+| Arquitectura (contradice o no está cubierto por el plan/decisiones) | PARÁS, lo marcás "requiere decisión de arquitectura" |
+
+**Regla de oro: ante la duda de si algo es menor o funcional, preguntá.** Este repo tiene clientes reales en producción.
+
+### Clasificación de riesgo
+
+- Solo docs/scripts sin efecto en runtime → 🟢, ejecutás con tu criterio.
+- Código de producción (controllers, models, views, menú, config) → 🟡, ciclo estándar con PR y validación.
+- Esquema de BD, identidad/login, credenciales, o algo que huela a arquitectura → 🔴, NO implementes — requiere workshop con Rodolfo.
+
+---
+
+## Restricciones duras de este repo
+
+1. **El esquema de `assetv2` está CONGELADO.** Asset sigue en producción y a futuro compartirá la base con `traz-tools-man`. No se agregan/modifican columnas ni tablas sin decisión 🔴.
+2. **Freeze de features.** Solo bugfixes para clientes actuales (por `develop`) y el trabajo de integración v3 (por `develop-v3`, excepción aprobada 2026-08-12). Cualquier otra feature: escalar.
+3. **Los artefactos WSO2 de `api/` y `_backend/api/` de ESTE repo son copias derivadas** — la fuente de verdad evoluciona en `traz-tools` (`_backend/api/` para EI 6.5 hoy, `ToolsAPIProject` como destino final). No editarlos acá sin coordinar la unificación.
+4. **Menús se inhabilitan, no se borran** (tabla `sismenu`): los cambios de visibilidad son datos reversibles, no DELETEs ni código muerto.
+5. **Credenciales legacy en el repo** (`constants.php`, configs): no agregar nuevas; las existentes están inventariadas en el plan de migración para rotación.
+6. **No romper el flujo v2.** `develop` y el ciclo de releases `v2.9.x` siguen operando para soporte; el trabajo v3 no debe pisarlo.
+
+## Convenciones de código (para código nuevo o tocado)
+
+- **Logging**: `log_message('DEBUG', '#TRAZA | ASSET | <Clase> | <metodo>() ...')`.
+- **Llamadas a tools**: siempre vía `application/libraries/REST.php`; URLs base y `empr_id`/`depo_id`/`pano_id` de tools salen de config, nunca hardcodeados ni resueltos por nombre en runtime.
+- **PHP nuevo**: PSR-12. No introducir SQL por concatenación de strings (usar query builder o binding); el legacy existente se corrige al tocarlo.
+- **No usar `$_POST` directo**: `$this->input->post()`.

--- a/doc/v3/CONTEXT-PACK.md
+++ b/doc/v3/CONTEXT-PACK.md
@@ -1,0 +1,61 @@
+# CONTEXT-PACK — traz-prod-assetplanner (workstream v3)
+
+> Versión -> 1.0, fecha 2026-08-12
+> Escrito contra: `traz-tools/doc/v3/CONTEXT-PACK.md` **v1.4** (último ADR: ADR-013) y `traz-tools/doc/migracion/assetplanner-a-traz-tools-man.md` del **2026-08-12** (PR #424).
+> **Chequeo de staleness:** si alguno de esos dos avanzó respecto de lo declarado acá, PARÁ y reportá antes de usar este resumen.
+
+## Objetivo
+
+Resumen operativo del workstream de integración de AssetPlanner con traz-tools v3, para quien ejecute tareas en este repo (Claude Code o un developer). Se lee ANTES de cualquier tarea, junto con `STATE.md`. NO es la fuente de verdad: las decisiones canónicas viven en los documentos de `traz-tools` referenciados abajo. No cubre el flujo de soporte v2 (`develop` → `master`), que sigue operando aparte.
+
+---
+
+## 1. Qué está pasando en este repo
+
+AssetPlanner corre en producción con clientes reales y tiene **dos frentes v3 activos**:
+
+1. **Requerimiento inmediato (cliente en el corto plazo):** asset deja de usar su almacén y sus herramientas propias, y consume los de traz-tools vía REST. Sin migración masiva de datos (validado con conteos en producción, ver §3). Es el contenido de las fases F1–F6 de `STATE.md`.
+2. **Migración del núcleo** a `traz-tools-man` (mediano plazo): plan completo en `traz-tools/doc/migracion/assetplanner-a-traz-tools-man.md`. Este requerimiento **adelanta su Etapa 5** y la vacía de migración de datos.
+
+## 2. Decisiones vigentes
+
+| # | Decisión | Fecha | Fuente |
+|---|---|---|---|
+| D1 | **Branching:** `develop-v3` (creada desde `develop`) es la base de todo el trabajo v3 en este repo, espejando el modelo de traz-tools. Un PR por fase del plan | 2026-08-12 | Rodolfo, sesión de kickoff |
+| D2 | **Almacén de asset se reemplaza, no se migra.** Menús inhabilitados (no borrados) en `sismenu`; models de almacén pasan de SQL a REST contra `ALMDataService`. Ningún cliente usa el almacén operativo de asset (validado, §3) | 2026-08-12 | Requerimiento del PM + conteos |
+| D3 | **Depósito único por convención:** en el setup de cada cliente se crea a mano establecimiento + depósito "Depósito \<empresa\>" en tools, se resuelve el `depo_id` UNA vez y se guarda en config de asset. El nombre es convención visual; el runtime usa SIEMPRE el id. Sin desplegables de depósito en pantallas de asset | 2026-08-12 | Requerimiento del PM |
+| D4 | **Puente de empresas:** el vínculo vive SOLO en PostgreSQL (`core.empresas.empr_id_mysql`, lo escribe la registración freemium). Asset NO guarda referencia a tools. Falta crear la query inversa `getEmpresaByMysqlId` en `COREDataService` (fase F1) y asset la cachea en sesión/config | 2026-08-12 | Verificado en `COREDataService.dbs:379-405` |
+| D5 | **DataServices = bus interno entre componentes.** Acceso puntual por id sin validación de usuario final está permitido para asset→tools. MCP sigue SIN usarlos directo (ahí la validación es obligatoria, ADR-009/013 de tools) | 2026-08-12 | Rodolfo |
+| D6 | **Mismo Bonita para asset y tools.** Los pedidos de materiales de ambos usan el mismo motor y el mismo proceso. Post-cutover, los pedidos se crean SOLO desde tools; en el interinato asset puede crearlos desde el flujo ejecutar-OT vía REST | 2026-08-12 | Rodolfo |
+| D7 | **Herramientas entra al mismo esquema que almacén** (reemplazo por `traz-comp-pan`/`PANDataservice`, "Pañol \<empresa\>" único). El único cliente real con datos es Caleras San Juan: 2 herramientas y 32 artículos → carga manual en el setup, no migración | 2026-08-12 | Conteos en producción (§3) |
+| D8 | **Excepción al freeze:** el plan de migración congela features en asset; este requerimiento es LA excepción aprobada. Cualquier otra feature nueva en asset sigue prohibida sin aprobación | 2026-08-12 | Rodolfo |
+| D9 | **Unificación WSO2 EI↔MI:** hoy los despliegues de tools salen de `traz-tools/_backend/api` (+`/dataservice`) sobre WSO2 EI 6.5; `ToolsAPIProject` (MI última versión) es solo MCP por ahora. Futuro: solo `ToolsAPIProject`. Funcionalmente DEBEN ser iguales — la sincronización es parte del trabajo, no un aparte | 2026-08-12 | Rodolfo |
+| D10 | **Esquema de `assetv2` congelado** mientras asset esté en producción (premisa del plan de migración: la futura convivencia con `traz-tools-man` comparte esta base) | 2026-08-12 | Plan de migración §5.1 |
+
+## 3. Datos duros que sostienen las decisiones (conteos en `assetv2` producción, 2026-08-12)
+
+- **Almacén operativo: 0 filas** en notas de pedido, remitos, órdenes de insumos, lotes y envíos. Supuesto "nadie usa almacenes de asset" **validado**.
+- **Catálogos con uso mínimo y concentrado:** `articles` 270 filas y `herramientas` 136, casi todo de empresas de prueba (ids 6/7/8, RuizSoft/RuizTech/RuizTech). Único cliente real con datos: **Caleras San Juan (id 1): 32 artículos, 2 herramientas, 10 filas en `tbl_otherramientas`** (histórico).
+- Referencias históricas en `tbl_ot*`/`tbl_preventivo*` de empresas de prueba: se ignoran. Las de Caleras: remapear a mano o aceptar como histórico de solo lectura (definir en F4).
+
+## 4. El gotcha más importante ahora mismo
+
+**La copia EI de `ALMDataService.dbs` (la que HOY despliega tools a producción) está desactualizada y rota:** `getArticulos2` tiene `WHERE A.empr_id = 1` **hardcodeado** y le falta el fix de aislamiento del join a `alm_lotes` (corregido solo en la copia MI el 2026-08-11). **Sincronizar EI←MI es prerrequisito (fase F1)** — si asset consume la copia EI tal cual, todos los clientes verían los artículos de la empresa 1.
+
+## 5. Restricciones duras
+
+- `initialize`/`tools/list`, JWT, MCP: NO aplican a este repo — asset no habla MCP. Asset habla REST plano contra DataServices (D5).
+- El `empr_id` de tools y el `id_empresa` de asset son numeraciones DISTINTAS. Nunca asumir que coinciden (el bug de las tools `alm_*` del 2026-08-11 en tools nació de esa confusión).
+- `empr_id_mysql` en `core.empresas` no tiene migración SQL formal en ningún repo (bloqueante conocido de tools) y no es único ni indexado — la fase F1 debe contemplarlo.
+- Los artefactos WSO2 de `api/` y `_backend/api/` de ESTE repo son copias derivadas; no editarlos acá (CLAUDE.md, Restricción 3).
+
+## 6. Dónde está cada cosa
+
+| Qué | Dónde |
+|---|---|
+| Estado vivo del workstream | `doc/v3/STATE.md` (este repo) |
+| Estado global del proyecto v3 | `traz-tools/doc/v3/STATE.md` |
+| Plan de migración completo (etapas, riesgos, pruebas) | `traz-tools/doc/migracion/assetplanner-a-traz-tools-man.md` |
+| Arquitectura MCP/identidad | `traz-tools/doc/v3/TRAZALOG_v3_MCP_ARCHITECTURE.md` + `traz-tools/doc/adr/` |
+| Artefactos WSO2 fuente de verdad | `traz-tools/_backend/api/` (EI 6.5, despliegue actual) y `traz-tools/_backend/api/ToolsAPIProject` (MI, destino final) |
+| DataServices relevantes | `ALMDataService.dbs`, `PANDataservice.dbs`, `COREDataService.dbs` (en ambas copias de tools) |

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -1,0 +1,48 @@
+# STATE.md — Estado vivo del workstream v3 de AssetPlanner
+
+## Objetivo
+
+Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: almacén, herramientas, y preparación de la migración del núcleo). Se actualiza al final de CADA tarea como parte del Definition of Done. NO cubre el soporte v2 (`develop`/`master`), ni el estado global del proyecto v3 — ese vive en `traz-tools/doc/v3/STATE.md` y este archivo solo lo complementa.
+
+> **Reglas de actualización** (mismas que el STATE de tools): Claude Code lo actualiza al cerrar cada tarea; se mantiene la estructura de secciones; es un tablero, no una bitácora.
+
+---
+
+**Workstream actual:** Requerimiento "asset consume ALM+PAN de tools" (cliente en el corto plazo) — adelanta la Etapa 5 del plan de migración.
+**Última actualización:** 2026-08-12 por Claude Code (F0: metodología y fundaciones).
+
+### Fases del plan y su estado
+
+> Regla: **cada fase entra por su propio PR (mínimo uno) contra `develop-v3`**. Una fase no arranca si la anterior que la bloquea no está mergeada.
+
+| Fase | Descripción | Repo donde se ejecuta | Clase | Estado | Rama / PR |
+|---|---|---|---|---|---|
+| F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE, branch protection pendiente de configurar en GitHub (Settings → Branches, requiere PR + no bypass) | asset | 🟢 | **En PR** | `docs/e0-metodologia-v3` |
+| F1 | Sincronizar `ALMDataService` EI←MI (fix aislamiento + parametrización de `getArticulos2` y revisión de las demás queries divergentes) + crear query `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + índice/unicidad de `empr_id_mysql` | **traz-tools** | 🟡 | Pendiente — **bloquea F3-F5** | — |
+| F2 | Checklist de setup por cliente: verificar vínculo `empr_id_mysql`, crear establecimiento + "Depósito \<empresa\>" + "Pañol \<empresa\>" en tools, cargar catálogo del cliente (Caleras: 32 artículos, 2 herramientas), registrar `empr_id`/`depo_id`/`pano_id` en config de asset. Documento autocontenido con DÓNDE se ejecuta cada paso | asset (doc) + manual | 🟢 | Pendiente | — |
+| F3 | Asset almacén → tools: inhabilitar menús de almacén en `sismenu`; models de almacén de SQL a REST (`REST.php` → `ALMDataService`); resolución de `empr_id` tools en sesión | asset | 🟡 | Pendiente — requiere F1 | — |
+| F4 | Asset herramientas → tools: ídem contra `PANDataservice`; autocompletes de herramientas en planes/OTs consumen REST; definir tratamiento de las 10 referencias históricas de Caleras en `tbl_otherramientas` (remapeo manual o histórico de solo lectura) | asset | 🟡 | Pendiente — requiere F1 | — |
+| F5 | Flujo ejecutar-OT: pedido de materiales vía REST contra el mismo Bonita (`Calendario.php:632-646`, `Tarea.php:684`, `view_OtEjecutar_modal.php`); pantallas de visualización de almacén → tools | asset | 🟡 | Pendiente — requiere F3 | — |
+| F6 | Prueba integral en DEV + piloto con el cliente del requerimiento | ambos | 🟡 | Pendiente — requiere F2-F5 | — |
+
+### Próxima acción
+
+1. Aprobar y mergear el PR de F0; configurar branch protection de `develop-v3` en GitHub (manual, Rodolfo).
+2. Arrancar F1 en `traz-tools` (es prerrequisito de todo lo demás): sincronización EI←MI de `ALMDataService` + `getEmpresaByMysqlId`. Sale de rama en traz-tools, PR a su `develop-v3`.
+3. En paralelo puede escribirse el checklist de F2 (doc, no bloquea ni se bloquea).
+
+### Decisiones recientes (últimas 5)
+
+| Fecha | Decisión | Referencia |
+|---|---|---|
+| 2026-08-12 | **Verificación en producción completada (read-only): almacén operativo de asset en CERO absoluto** (pedidos, remitos, órdenes de insumos, lotes, envíos: 0 filas). Catálogos con uso mínimo: el único cliente real con datos es Caleras San Juan (32 artículos, 2 herramientas, 10 refs históricas en `tbl_otherramientas`); el resto es de empresas de prueba. Habilita D2 y D7: reemplazo sin migración masiva, con carga manual del catálogo de Caleras en el setup | CONTEXT-PACK §3, script `verify-asset-herr-alm-usage.sh` (scratchpad de la sesión) |
+| 2026-08-12 | **Encontrado el gotcha que bloquea consumir ALM hoy: la copia EI de `ALMDataService.dbs` tiene `getArticulos2` con `WHERE A.empr_id = 1` hardcodeado y sin el fix de aislamiento** del 2026-08-11 (que está solo en la copia MI). La sincronización EI←MI pasa de "mejora pendiente" a prerrequisito (F1) | CONTEXT-PACK §4 |
+| 2026-08-12 | **No existe lookup inverso `empr_id_mysql → empr_id`**: la registración freemium escribe el vínculo solo en `core.empresas.empr_id_mysql` (el INSERT en assetv2 no guarda nada de tools). Hay que crear `getEmpresaByMysqlId` en `COREDataService` (F1). La columna además no es única ni está indexada, y sigue sin migración SQL formal | `COREDataService.dbs:379-405` |
+| 2026-08-12 | **`develop-v3` creada en este repo desde `develop`** (que está contenida en `master`; master solo suma los 16 merges de tags `v2.9.x`). Todo el trabajo v3 entra por PR contra ella, un PR por fase | D1, CLAUDE.md |
+| 2026-08-12 | **Requerimiento aprobado por el PM con 7 respuestas clave**: puente de empresas por lookup REST (no tocar esquema asset), depósito por id resuelto en setup, unificación EI↔MI progresiva, DataServices como bus interno sin validación por usuario para acceso por id, mismo Bonita, inhabilitar (no borrar) menús, y excepción explícita al freeze | CONTEXT-PACK §2 (D1-D10) |
+
+### Bloqueos
+
+- **F1 bloquea F3, F4 y F5.** Sin la sincronización EI←MI, asset consumiría queries con `empr_id=1` hardcodeado.
+- **Branch protection de `develop-v3` en este repo**: pendiente de configurar en GitHub (solo Rodolfo tiene admin).
+- Heredados de tools (informativos): `empr_id_mysql` sin migración formal; credenciales legacy en configs de ambos repos pendientes de rotación (inventariadas en el plan de migración).


### PR DESCRIPTION
## Qué cambia

Fase F0 del requerimiento "asset consume ALM+PAN de tools": se adapta a este repo la metodología de trabajo de traz-tools (CICD_STRATEGY §5-bis). Tres archivos nuevos:

- `CLAUDE.md` — instrucciones del repo: modelo de ramas (`develop-v3` para v3, `develop` intacto para soporte v2), un PR por fase, formato de PR, reglas de escalamiento, clases de riesgo, restricciones duras (esquema `assetv2` congelado, freeze de features con esta única excepción, artefactos WSO2 locales como copias derivadas).
- `doc/v3/CONTEXT-PACK.md` — resumen operativo con las 10 decisiones vigentes (D1-D10) del requerimiento, los datos que las sostienen y el chequeo de staleness contra los docs canónicos de traz-tools.
- `doc/v3/STATE.md` — tablero de fases F0-F6 con dependencias, próxima acción y bloqueos.

## Por qué

Decisión del PM (2026-08-12): usar en asset la misma metodología que traz-tools usa para MCP, con `develop-v3` propio y PRs por fase. El trabajo previo de migración (2024) fracasó en trazabilidad justamente por no tener esto: 3 commits "backup" en una rama personal, sin PRs ni documentación.

## Cómo lo verifiqué

- `develop-v3` creada desde `develop` y publicada (develop está contenida en master; master solo suma los 16 merges de tags `v2.9.x`).
- Las decisiones D2/D7 (reemplazo sin migración de datos) quedaron respaldadas por conteos read-only en `assetv2` producción ejecutados hoy: almacén operativo en 0 absoluto; único cliente real con datos de catálogo es Caleras San Juan (32 artículos, 2 herramientas).
- El gotcha bloqueante documentado (copia EI de `ALMDataService` con `empr_id=1` hardcodeado y sin fix de aislamiento) verificado por diff directo entre `_backend/api/dataservice/ALMDataService.dbs` y la copia de `ToolsAPIProject` en traz-tools.
- Los tres archivos abren con `## Objetivo` / propósito según la convención de docs del proyecto.

## Pendiente manual tras el merge

- Configurar branch protection de `develop-v3` en GitHub (Settings → Branches: require PR, no bypass) — requiere admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s