### PR TITLE
docs(setup): checklist de setup por cliente para ALM+PAN de tools [F2]

### DIFF
--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -9,7 +9,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 ---
 
 **Workstream actual:** Requerimiento "asset consume ALM+PAN de tools" (cliente en el corto plazo) — adelanta la Etapa 5 del plan de migración.
-**Última actualización:** 2026-08-12 por Claude Code (F0: metodología y fundaciones).
+**Última actualización:** 2026-08-14 por Claude Code (F0 mergeada; F1 completada y en PR en traz-tools).
 
 ### Fases del plan y su estado
 
@@ -17,8 +17,8 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 | Fase | Descripción | Repo donde se ejecuta | Clase | Estado | Rama / PR |
 |---|---|---|---|---|---|
-| F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE, branch protection pendiente de configurar en GitHub (Settings → Branches, requiere PR + no bypass) | asset | 🟢 | **En PR** | `docs/e0-metodologia-v3` |
-| F1 | Sincronizar `ALMDataService` EI←MI (fix aislamiento + parametrización de `getArticulos2` y revisión de las demás queries divergentes) + crear query `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + índice/unicidad de `empr_id_mysql` | **traz-tools** | 🟡 | Pendiente — **bloquea F3-F5** | — |
+| F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE | asset | 🟢 | **Mergeada** (branch protection de `develop-v3` configurada por Rodolfo el 2026-08-14) | PR #322 |
+| F1 | Sincronizar `ALMDataService` EI←MI + `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + migración formal de `empr_id_mysql` | **traz-tools** | 🟡 | **Completada, en PR (bloquea F3-F5 hasta el merge).** 84 queries idénticas en ambas copias; fix de aislamiento en las 3 queries de artículos verificado contra Postgres DEV (empresa 87: 7.534 → 4.532 de stock); lookup probado (match y no-match); `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` idempotente, **aplicación manual pendiente en TEST/PROD**; CAR del MI buildea con los fixes. El hardcode `empr_id = 1` de la copia EI quedó eliminado | traz-tools PR #426 (mergear después del #425) |
 | F2 | Checklist de setup por cliente: verificar vínculo `empr_id_mysql`, crear establecimiento + "Depósito \<empresa\>" + "Pañol \<empresa\>" en tools, cargar catálogo del cliente (Caleras: 32 artículos, 2 herramientas), registrar `empr_id`/`depo_id`/`pano_id` en config de asset. Documento autocontenido con DÓNDE se ejecuta cada paso | asset (doc) + manual | 🟢 | Pendiente | — |
 | F3 | Asset almacén → tools: inhabilitar menús de almacén en `sismenu`; models de almacén de SQL a REST (`REST.php` → `ALMDataService`); resolución de `empr_id` tools en sesión | asset | 🟡 | Pendiente — requiere F1 | — |
 | F4 | Asset herramientas → tools: ídem contra `PANDataservice`; autocompletes de herramientas en planes/OTs consumen REST; definir tratamiento de las 10 referencias históricas de Caleras en `tbl_otherramientas` (remapeo manual o histórico de solo lectura) | asset | 🟡 | Pendiente — requiere F1 | — |
@@ -27,9 +27,9 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 ### Próxima acción
 
-1. Aprobar y mergear el PR de F0; configurar branch protection de `develop-v3` en GitHub (manual, Rodolfo).
-2. Arrancar F1 en `traz-tools` (es prerrequisito de todo lo demás): sincronización EI←MI de `ALMDataService` + `getEmpresaByMysqlId`. Sale de rama en traz-tools, PR a su `develop-v3`.
-3. En paralelo puede escribirse el checklist de F2 (doc, no bloquea ni se bloquea).
+1. Aprobar y mergear en `traz-tools`: **#425** (landeo del registro REQ-ASSET-ALM que quedó huérfano tras el merge de #424) y después **#426** (F1).
+2. Rodolfo: aplicar `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` a mano en TEST cuando corresponda (DEV ya verificado sin duplicados).
+3. Escribir el checklist de F2 (doc, no depende de F1) y arrancar F3 en este repo apenas #426 esté mergeado.
 
 ### Decisiones recientes (últimas 5)
 
@@ -43,6 +43,5 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 ### Bloqueos
 
-- **F1 bloquea F3, F4 y F5.** Sin la sincronización EI←MI, asset consumiría queries con `empr_id=1` hardcodeado.
-- **Branch protection de `develop-v3` en este repo**: pendiente de configurar en GitHub (solo Rodolfo tiene admin).
-- Heredados de tools (informativos): `empr_id_mysql` sin migración formal; credenciales legacy en configs de ambos repos pendientes de rotación (inventariadas en el plan de migración).
+- **F1 en PR (traz-tools #426) — F3-F5 siguen bloqueadas hasta su merge.** El hardcode `empr_id=1` ya está corregido en la rama.
+- Heredados de tools (informativos): la migración formal de `empr_id_mysql` ya existe como script (F1) pero falta aplicarla en TEST/PROD; credenciales legacy en configs de ambos repos pendientes de rotación (inventariadas en el plan de migración).

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -9,7 +9,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 ---
 
 **Workstream actual:** Requerimiento "asset consume ALM+PAN de tools" (cliente en el corto plazo) — adelanta la Etapa 5 del plan de migración.
-**Última actualización:** 2026-08-14 por Claude Code (F0 mergeada; F1 completada y en PR en traz-tools).
+**Última actualización:** 2026-08-14 por Claude Code (F2: checklist de setup por cliente, en PR).
 
 ### Fases del plan y su estado
 
@@ -19,7 +19,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 |---|---|---|---|---|---|
 | F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE | asset | 🟢 | **Mergeada** (branch protection de `develop-v3` configurada por Rodolfo el 2026-08-14) | PR #322 |
 | F1 | Sincronizar `ALMDataService` EI←MI + `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + migración formal de `empr_id_mysql` | **traz-tools** | 🟡 | **Completada, en PR (bloquea F3-F5 hasta el merge).** 84 queries idénticas en ambas copias; fix de aislamiento en las 3 queries de artículos verificado contra Postgres DEV (empresa 87: 7.534 → 4.532 de stock); lookup probado (match y no-match); `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` idempotente, **aplicación manual pendiente en TEST/PROD**; CAR del MI buildea con los fixes. El hardcode `empr_id = 1` de la copia EI quedó eliminado | traz-tools PR #426 (mergear después del #425) |
-| F2 | Checklist de setup por cliente: verificar vínculo `empr_id_mysql`, crear establecimiento + "Depósito \<empresa\>" + "Pañol \<empresa\>" en tools, cargar catálogo del cliente (Caleras: 32 artículos, 2 herramientas), registrar `empr_id`/`depo_id`/`pano_id` en config de asset. Documento autocontenido con DÓNDE se ejecuta cada paso | asset (doc) + manual | 🟢 | Pendiente | — |
+| F2 | Checklist de setup por cliente | asset (doc) + manual | 🟢 | **Completada, en PR.** `doc/v3/setup-cliente-alm-pan.md`: 8 pasos autocontenidos (vínculo de empresa, usuarios Dnato/Bonita, establecimiento, depósito, pañol, config, catálogo, verificación end-to-end), cada uno con DÓNDE se ejecuta, comando y verificación. Decisión técnica tomada: **la config por empresa (`DEPO_ID`/`PANO_ID`/`ESTA_ID`) vive en `core.tablas` de tools** (clave `ASSET`+`DEPO`/`PANO`/`ESTA`, vía `setTabla`/`getTablaValorXEmp` — el trigger `set_tabla_id_bui` arma la clave), NO en el esquema congelado de asset. Contratos verificados contra los `.dbs` y las bases de DEV (columnas reales de `articles`/`herramientas`, trigger de `core.tablas`, seriales). **La ejecución manual del checklist para el primer cliente queda pendiente** (requiere F1 desplegada) | `docs/f2-checklist-setup-cliente` — PR abierto |
 | F3 | Asset almacén → tools: inhabilitar menús de almacén en `sismenu`; models de almacén de SQL a REST (`REST.php` → `ALMDataService`); resolución de `empr_id` tools en sesión | asset | 🟡 | Pendiente — requiere F1 | — |
 | F4 | Asset herramientas → tools: ídem contra `PANDataservice`; autocompletes de herramientas en planes/OTs consumen REST; definir tratamiento de las 10 referencias históricas de Caleras en `tbl_otherramientas` (remapeo manual o histórico de solo lectura) | asset | 🟡 | Pendiente — requiere F1 | — |
 | F5 | Flujo ejecutar-OT: pedido de materiales vía REST contra el mismo Bonita (`Calendario.php:632-646`, `Tarea.php:684`, `view_OtEjecutar_modal.php`); pantallas de visualización de almacén → tools | asset | 🟡 | Pendiente — requiere F3 | — |
@@ -29,17 +29,18 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 1. Aprobar y mergear en `traz-tools`: **#425** (landeo del registro REQ-ASSET-ALM que quedó huérfano tras el merge de #424) y después **#426** (F1).
 2. Rodolfo: aplicar `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` a mano en TEST cuando corresponda (DEV ya verificado sin duplicados).
-3. Escribir el checklist de F2 (doc, no depende de F1) y arrancar F3 en este repo apenas #426 esté mergeado.
+3. Ejecutar el checklist de F2 (`doc/v3/setup-cliente-alm-pan.md`) para el cliente del requerimiento, una vez que F1 esté desplegada en el ambiente.
+4. Arrancar F3 en este repo apenas #426 esté mergeado — el código de F3 lee la config con la clave `ASSET`+`DEPO`/`PANO`/`ESTA` definida en el checklist.
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
+| 2026-08-14 | **La config por empresa que asset necesita en runtime (`DEPO_ID`/`PANO_ID`/`ESTA_ID`) se guarda en `core.tablas` de tools, no en asset.** Razones: el esquema de `assetv2` está congelado (D10), `core.tablas` ya soporta valores por empresa (`empr_id` + trigger `set_tabla_id_bui` que arma la clave) y tiene lectura/escritura REST existentes (`getTablaValorXEmp`/`setTabla`). Convención: tabla `ASSET`, valores `DEPO`/`PANO`/`ESTA`, el id viaja en `descripcion`. Decisión técnica menor tomada en F2 — F3 debe leer con esa clave | `doc/v3/setup-cliente-alm-pan.md` paso 6 |
 | 2026-08-12 | **Verificación en producción completada (read-only): almacén operativo de asset en CERO absoluto** (pedidos, remitos, órdenes de insumos, lotes, envíos: 0 filas). Catálogos con uso mínimo: el único cliente real con datos es Caleras San Juan (32 artículos, 2 herramientas, 10 refs históricas en `tbl_otherramientas`); el resto es de empresas de prueba. Habilita D2 y D7: reemplazo sin migración masiva, con carga manual del catálogo de Caleras en el setup | CONTEXT-PACK §3, script `verify-asset-herr-alm-usage.sh` (scratchpad de la sesión) |
 | 2026-08-12 | **Encontrado el gotcha que bloquea consumir ALM hoy: la copia EI de `ALMDataService.dbs` tiene `getArticulos2` con `WHERE A.empr_id = 1` hardcodeado y sin el fix de aislamiento** del 2026-08-11 (que está solo en la copia MI). La sincronización EI←MI pasa de "mejora pendiente" a prerrequisito (F1) | CONTEXT-PACK §4 |
 | 2026-08-12 | **No existe lookup inverso `empr_id_mysql → empr_id`**: la registración freemium escribe el vínculo solo en `core.empresas.empr_id_mysql` (el INSERT en assetv2 no guarda nada de tools). Hay que crear `getEmpresaByMysqlId` en `COREDataService` (F1). La columna además no es única ni está indexada, y sigue sin migración SQL formal | `COREDataService.dbs:379-405` |
 | 2026-08-12 | **`develop-v3` creada en este repo desde `develop`** (que está contenida en `master`; master solo suma los 16 merges de tags `v2.9.x`). Todo el trabajo v3 entra por PR contra ella, un PR por fase | D1, CLAUDE.md |
-| 2026-08-12 | **Requerimiento aprobado por el PM con 7 respuestas clave**: puente de empresas por lookup REST (no tocar esquema asset), depósito por id resuelto en setup, unificación EI↔MI progresiva, DataServices como bus interno sin validación por usuario para acceso por id, mismo Bonita, inhabilitar (no borrar) menús, y excepción explícita al freeze | CONTEXT-PACK §2 (D1-D10) |
 
 ### Bloqueos
 

--- a/doc/v3/setup-cliente-alm-pan.md
+++ b/doc/v3/setup-cliente-alm-pan.md
@@ -1,0 +1,220 @@
+# Setup de un cliente de AssetPlanner para consumir Almacén y Pañol de traz-tools
+
+## Objetivo
+
+Checklist para configurar a mano, una vez por cliente, todo lo que AssetPlanner necesita del lado de traz-tools antes de que ese cliente use el almacén (`traz-comp-almacenes`) y el pañol (`traz-comp-pan`) de tools: empresa vinculada, establecimiento, depósito único, pañol único, catálogo inicial y config por empresa. Lo ejecuta quien haga el onboarding (hoy Rodolfo), completo y en orden — cada paso dice DÓNDE se ejecuta. **No cubre** los cambios de código de asset (fases F3-F5, ver `STATE.md`) ni el alta de la infraestructura WSO2 (ver `traz-tools/doc/infra/`).
+
+---
+
+**Prerrequisitos (verificar antes de arrancar):**
+
+1. **F1 mergeada Y desplegada** en el WSO2 del ambiente: el CAR/artefactos con la sincronización de `ALMDataService` y el lookup `getEmpresaByMysqlId` (traz-tools PR #426). Sin esto, las verificaciones REST de este checklist fallan con 404 o devuelven datos de la empresa 1.
+2. **Migración `empr_id_mysql` aplicada** en el PostgreSQL del ambiente: `traz-tools/scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` (idempotente; en DEV ya está verificada).
+3. Acceso de red al ambiente (VPN para DEV) y credenciales de las bases.
+
+**Endpoints por ambiente** (usar el que corresponda en TODOS los pasos; los ejemplos de este doc usan DEV):
+
+| Qué | DEV | PROD (completar cuando exista) |
+|---|---|---|
+| WSO2 EI (DataServices) | `http://10.142.0.13:8280/services` | — |
+| PostgreSQL tools | `10.142.0.13:5432`, base `tools_prod_t` | — |
+| MariaDB assetv2 | `10.142.0.13:3306`, base `assetv2` | — |
+| App tools (pantallas) | según ambiente | — |
+
+**Convenciones de nombres (decisión D3/D7):** el depósito se llama `Depósito <NombreEmpresa>` y el pañol `Pañol <NombreEmpresa>`. El nombre es para humanos; **el runtime usa SIEMPRE los ids** (`depo_id`, `pano_id`) que este checklist deja registrados en el paso 6.
+
+---
+
+## Datos de entrada (completar antes de empezar)
+
+| Dato | Valor |
+|---|---|
+| Nombre de la empresa | |
+| `id_empresa` en assetv2 (MariaDB) | |
+| CUIT | |
+| Usuarios que van a operar pantallas de tools (nombre + email) | |
+
+---
+
+## Paso 1 — Vincular la empresa (assetv2 ↔ tools)
+
+**Dónde: terminal con `psql` contra el PostgreSQL de tools del ambiente.**
+
+1. Verificar si la empresa ya está vinculada:
+
+   ```sql
+   SELECT empr_id, nombre, descripcion, empr_id_mysql FROM core.empresas WHERE empr_id_mysql = <ID_ASSET>;
+   ```
+
+   - **Devuelve una fila** → vinculada. Anotar el `empr_id` y saltar al paso 2.
+   - **Vacío** → seguir.
+
+2. Verificar si la empresa existe en tools sin vínculo (buscar por nombre/CUIT):
+
+   ```sql
+   SELECT empr_id, nombre, cuit, empr_id_mysql FROM core.empresas WHERE eliminado IS NOT TRUE AND (nombre ILIKE '%<parte del nombre>%' OR cuit = '<CUIT>');
+   ```
+
+   - **Existe** → vincular: `UPDATE core.empresas SET empr_id_mysql = <ID_ASSET> WHERE empr_id = <EMPR_ID>;`
+   - **No existe** → crearla y vincularla en un paso (los demás campos se completan después desde las pantallas de tools si hace falta):
+
+   ```sql
+   INSERT INTO core.empresas (nombre, descripcion, cuit, empr_id_mysql) VALUES ('<NombreEmpresa>', '<NombreEmpresa>', '<CUIT>', <ID_ASSET>) RETURNING empr_id;
+   ```
+
+3. **Verificación (obligatoria)** — desde una terminal con acceso al WSO2 del ambiente, probar el lookup que va a usar asset en runtime:
+
+   ```bash
+   curl -s http://10.142.0.13:8280/services/COREDataService/empresa/porAssetId/<ID_ASSET>
+   ```
+
+   Debe devolver `{"empresa":{"empr_id":"<EMPR_ID>","descripcion":"..."}}`. Si devuelve vacío o 404, no seguir: o falta el deploy de F1 o el UPDATE no se aplicó.
+
+> ⚠️ La unicidad importa: un `id_empresa` de asset no puede apuntar a dos empresas de tools. El índice único del prerrequisito 2 lo garantiza — si el UPDATE falla por duplicado, hay una inconsistencia previa que resolver antes de seguir.
+
+**Anotar: `EMPR_ID` = ______**
+
+---
+
+## Paso 2 — Acceso de los usuarios a las pantallas de tools
+
+Los usuarios del cliente van a ver las pantallas de almacén y pañol **en tools**, no en asset (decisión del requerimiento, punto 5). Necesitan poder loguearse en tools.
+
+**Dónde: portal de Dnato del ambiente (alta de usuarios) + portal de Bonita si falta el grupo.**
+
+1. Dar de alta los usuarios del cliente en Dnato, asociados a la empresa `EMPR_ID`.
+2. **Verificación**: loguearse en la app de tools con uno de esos usuarios. Debe entrar y ver el menú.
+3. Si el login funciona pero el menú sale vacío o fallan las bandejas: falta el grupo de Bonita de la empresa (formato `{empr_id}-{nombre}`, ej. `9000-Termotanques` — ver `traz-tools/doc/v3/deployment-gcp.md` §7.0-quater). Crearlo en el portal de Bonita del ambiente y reintentar.
+
+> Nota: si la empresa se creó por la registración freemium, esto ya existe. El caso manual del paso 1.2 es el que puede requerir crear el grupo a mano.
+
+---
+
+## Paso 3 — Establecimiento
+
+El depósito y el pañol cuelgan de un establecimiento (`prd.establecimientos`), así que va primero.
+
+**Dónde: terminal con `curl` contra el WSO2 del ambiente.**
+
+```bash
+curl -s -X POST http://10.142.0.13:8280/services/ALMDataService/establecimientos -H "Content-Type: application/json" -d '{"nombre":"<NombreEmpresa>","longitud":"","latitud":"","calles":"","altura":"","localidad":"","pais":"Argentina","usuario":"setup","empr_id":"<EMPR_ID>"}'
+```
+
+**Verificación** (psql): `SELECT esta_id, nombre FROM prd.establecimientos WHERE empr_id = <EMPR_ID>;`
+
+Alternativa por pantalla: app de tools → módulo Producción → Establecimientos (controller `traz-prod-trazasoft/general/Establecimiento.php`).
+
+**Anotar: `ESTA_ID` = ______**
+
+---
+
+## Paso 4 — Depósito único "Depósito \<NombreEmpresa\>"
+
+No hay pantalla ni query de alta de depósito en `ALMDataService` — se crea por SQL.
+
+**Dónde: terminal con `psql` contra el PostgreSQL de tools del ambiente.**
+
+```sql
+INSERT INTO alm.alm_depositos (descripcion, nombre, esta_id, empr_id, estado, eliminado) VALUES ('Depósito <NombreEmpresa>', 'Depósito <NombreEmpresa>', <ESTA_ID>, <EMPR_ID>, 'AC', false) RETURNING depo_id;
+```
+
+**Verificación** (curl — es la misma consulta que va a usar asset):
+
+```bash
+curl -s http://10.142.0.13:8280/services/ALMDataService/mcp/depositos/<EMPR_ID>
+```
+
+Debe listar el depósito recién creado con su `depo_id` y el establecimiento.
+
+**Anotar: `DEPO_ID` = ______**
+
+---
+
+## Paso 5 — Pañol único "Pañol \<NombreEmpresa\>"
+
+El pañol no tiene ABM en pantalla — se crea por REST contra `PANDataservice`.
+
+**Dónde: terminal con `curl` contra el WSO2 del ambiente.**
+
+```bash
+curl -s -X POST http://10.142.0.13:8280/services/PANDataservice/panol -H "Content-Type: application/json" -d '{"descripcion":"Pañol <NombreEmpresa>","usuario_app":"setup","empr_id":"<EMPR_ID>","esta_id":"<ESTA_ID>","nombre":"Pañol <NombreEmpresa>"}'
+```
+
+Devuelve `{"respuesta":{"pano_id":"<PANO_ID>"}}`.
+
+**Verificación**: `curl -s http://10.142.0.13:8280/services/PANDataservice/panol/empresa/<EMPR_ID>`
+
+**Anotar: `PANO_ID` = ______**
+
+---
+
+## Paso 6 — Registrar la config por empresa (la que va a leer asset)
+
+Los tres ids quedan guardados en `core.tablas` (tabla genérica clave-valor de tools, con soporte por empresa — el trigger `set_tabla_id_bui` arma la clave). Es lo que F3 va a leer en runtime en lugar de resolver nada por nombre.
+
+**Dónde: terminal con `curl` contra el WSO2 del ambiente.** Un POST por id:
+
+```bash
+curl -s -X POST http://10.142.0.13:8280/services/COREDataService/tablas -H "Content-Type: application/json" -d '{"tabla":"ASSET","valor":"DEPO","valor2":"","valor3":"","descripcion":"<DEPO_ID>","empr_id":"<EMPR_ID>"}'
+curl -s -X POST http://10.142.0.13:8280/services/COREDataService/tablas -H "Content-Type: application/json" -d '{"tabla":"ASSET","valor":"PANO","valor2":"","valor3":"","descripcion":"<PANO_ID>","empr_id":"<EMPR_ID>"}'
+curl -s -X POST http://10.142.0.13:8280/services/COREDataService/tablas -H "Content-Type: application/json" -d '{"tabla":"ASSET","valor":"ESTA","valor2":"","valor3":"","descripcion":"<ESTA_ID>","empr_id":"<EMPR_ID>"}'
+```
+
+**Verificación** — leer la config como la va a leer asset (`getTablaValorXEmp`):
+
+```bash
+curl -s http://10.142.0.13:8280/services/COREDataService/tabla/ASSET/valor/DEPO/empresa/<EMPR_ID>
+curl -s http://10.142.0.13:8280/services/COREDataService/tabla/ASSET/valor/PANO/empresa/<EMPR_ID>
+```
+
+Cada uno debe devolver el id guardado en `descripcion`.
+
+> La clave `ASSET` + `DEPO`/`PANO`/`ESTA` es la convención que asume F3. Si se cambia acá, cambiarla también en el código de F3.
+
+---
+
+## Paso 7 — Catálogo inicial (artículos y herramientas)
+
+Solo si el cliente ya tenía datos de catálogo en asset. Para **Caleras San Juan** (`id_empresa=1` en assetv2): 32 artículos y 2 herramientas (conteo del 2026-08-12).
+
+**7a. Extraer lo que hay en asset — dónde: terminal con `mysql` contra assetv2 del ambiente:**
+
+```sql
+SELECT artId, artBarCode, artDescription, artCoste, punto_pedido, unidadmedida FROM articles WHERE id_empresa = <ID_ASSET> AND artEstado != 'AN';
+SELECT herrId, herrcodigo, herrmarca, herrdescrip FROM herramientas WHERE id_empresa = <ID_ASSET> AND equip_estad != 'AN';
+```
+
+**7b. Cargar artículos — dónde: app de tools con un usuario de la empresa → módulo Almacenes → Artículos** (controller `traz-comp-almacenes/Articulo.php`). Carga manual, uno por uno — además de cargar datos, valida que las pantallas funcionan para esta empresa.
+
+**7c. Cargar herramientas — dónde: app de tools → módulo Pañol → Herramientas** (controller `traz-comp-pan/Herramienta.php`), asignándolas al pañol del paso 5.
+
+> ⚠️ La marca de la herramienta en tools es una referencia a `core.tablas` (no texto libre como en asset, donde además marca y modelo viajan mezclados — ej. `'Escalera 7 peldaño - Ayinco'`). Cargar por pantalla resuelve esto: la pantalla ofrece las marcas existentes y el desdoblamiento marca/modelo se decide a ojo en el momento.
+
+**Verificación** (curl):
+
+```bash
+curl -s http://10.142.0.13:8280/services/ALMDataService/articulos/<EMPR_ID>
+curl -s http://10.142.0.13:8280/services/PANDataservice/herramientas/empresa/<EMPR_ID>
+```
+
+Los conteos deben coincidir con lo extraído en 7a (menos lo que se haya decidido no migrar).
+
+> Las referencias históricas de asset (ej. las 10 filas de `tbl_otherramientas` de Caleras que apuntan a `herrId` viejos) NO se tocan en el setup — su tratamiento se define en F4.
+
+---
+
+## Paso 8 — Verificación final end-to-end
+
+1. **Lookup**: `curl .../COREDataService/empresa/porAssetId/<ID_ASSET>` → devuelve `EMPR_ID`. ✅
+2. **Config**: los 3 curls del paso 6 devuelven `DEPO_ID`, `PANO_ID`, `ESTA_ID`. ✅
+3. **Catálogo**: los 2 curls del paso 7 listan lo cargado. ✅
+4. **Aislamiento** (importante): repetir el curl de artículos con el `EMPR_ID` de OTRA empresa — no debe incluir nada de esta. ✅
+5. **Pantallas**: login en tools con un usuario del cliente → ve sus artículos en Almacenes y sus herramientas en Pañol. ✅
+
+## Registro de clientes configurados
+
+Completar una fila por cliente al terminar (este archivo se actualiza por PR, como todo):
+
+| Fecha | Empresa | `ID_ASSET` | `EMPR_ID` | `ESTA_ID` | `DEPO_ID` | `PANO_ID` | Catálogo cargado | Quién |
+|---|---|---|---|---|---|---|---|---|
+| | | | | | | | | |


### PR DESCRIPTION
## Qué cambia

Fase **F2**: nuevo `doc/v3/setup-cliente-alm-pan.md` — el checklist autocontenido que se ejecuta una vez por cliente antes de que use el almacén y el pañol de tools. 8 pasos, cada uno con DÓNDE se ejecuta (psql / curl / pantalla de tools / portal Dnato-Bonita), el comando concreto y su verificación:

1. Vínculo de empresa (con los 3 casos: vinculada / existe sin vínculo / no existe) + verificación por el lookup `porAssetId` que asset usará en runtime.
2. Acceso de usuarios a tools (Dnato + grupo Bonita).
3. Establecimiento → 4. Depósito único → 5. Pañol único (con anotación de `ESTA_ID`/`DEPO_ID`/`PANO_ID`).
6. **Config por empresa en `core.tablas`** — decisión técnica tomada acá (ver abajo).
7. Catálogo inicial (extracción desde assetv2 con las columnas reales + carga por pantalla; para Caleras: 32 artículos, 2 herramientas).
8. Verificación final end-to-end, incluido el chequeo de aislamiento contra otra empresa.

Incluye tabla de registro de clientes configurados y actualiza `STATE.md` (F2 → en PR, decisión registrada).

## Por qué

Fase F2 del plan (STATE.md). El requerimiento define depósito y pañol únicos por convención con ids resueltos en el setup (D3/D7) — este checklist es ese setup, escrito para poder ejecutarse leyendo SOLO el documento.

**Decisión técnica menor tomada** (documentada según la regla de escalamiento): la config por empresa vive en `core.tablas` de tools (clave `ASSET` + `DEPO`/`PANO`/`ESTA`, id en `descripcion`), NO en asset — porque el esquema de `assetv2` está congelado (D10) y `core.tablas` ya tiene soporte por empresa con lectura/escritura REST existentes. F3 leerá con esa clave. Si preferís otro mecanismo, es el momento de decirlo: cambiar después de F3 cuesta más.

## Cómo lo verifiqué

Es documentación, pero cada contrato citado está verificado contra el código y las bases de DEV (VPN arriba):
- Resources y parámetros reales de `setTabla`, `getTablaValorXEmp`, `setEstablecimiento`, `panolSet`, `herramientasSet`, `herramientasGet`, `panolGet`, `getDepositosMcp` — extraídos de los `.dbs` (copias EI post-F1).
- Trigger `set_tabla_id_bui` de `core.tablas` confirmado en DEV (arma la clave `{empr_id}-{tabla}{valor}` que asume el lookup).
- Columnas reales de `articles` y `herramientas` en assetv2 (el SQL de extracción del paso 7a usa `artBarCode`/`artDescription`/etc., no nombres inventados).
- Seriales de `core.empresas`, `prd.establecimientos`, `alm.alm_depositos` y `pan.panol` confirmados (los INSERT con RETURNING funcionan).
- Alta de depósito por SQL porque NO existe query de inserción en `ALMDataService` (verificado); pañol por REST porque no tiene ABM en pantalla (verificado en `traz-comp-pan`).

## Dependencias

- La rama incluye el commit de #323 (actualización de STATE por F1) — mergear #323 primero deja este PR solo con F2, o mergear este directamente y cerrar #323.
- La **ejecución** del checklist requiere F1 desplegada en el ambiente (traz-tools #426 mergeado + CAR/artefactos redeployados + script SQL aplicado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s