### PR TITLE
feat(alm): almacén de asset consume el catálogo de tools vía REST [F3]

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -194,6 +194,13 @@ define('REST_MAN', 'http://10.142.0.13:8280/services/MANDataService/');
 define('HOST', 'http://10.142.0.13:8280');
 define('REST_API_BPM', HOST.'/tools/bpm/proceso/instancia');
 define('REST_PRO', HOST.'/services/PRODataService');
+
+#INTEGRACION TRAZ-TOOLS (REQ-ASSET-ALM) — hoy es el mismo WSO2 del ambiente (HOST);
+#si tools pasa a otro host/MI, ajustar solo HOST_TOOLS.
+define('HOST_TOOLS', HOST);
+define('REST_TOOLS_CORE', HOST_TOOLS.'/services/COREDataService');
+define('REST_TOOLS_ALM', HOST_TOOLS.'/services/ALMDataService');
+define('REST_TOOLS_PAN', HOST_TOOLS.'/services/PANDataservice');
 /*
 |--------------------------------------------------------------------------
 | REPORTES

--- a/application/helpers/tools_helper.php
+++ b/application/helpers/tools_helper.php
@@ -1,0 +1,213 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+/**
+ * Helper de integración con traz-tools (REQ-ASSET-ALM, fase F3).
+ *
+ * AssetPlanner deja de leer su catálogo local de almacén (tabla `articles`)
+ * y consume el de traz-tools vía REST (ALMDataService). Este helper resuelve:
+ *   - el empr_id de tools a partir del id_empresa de asset (lookup porAssetId,
+ *     cacheado en sesión) — nunca asumir que ambos ids coinciden;
+ *   - la config por empresa registrada en el setup del cliente (core.tablas,
+ *     clave ASSET + DEPO/PANO/ESTA — ver doc/v3/setup-cliente-alm-pan.md paso 6);
+ *   - el catálogo de artículos de tools, con cache por request.
+ *
+ * Si la empresa no está vinculada en tools (core.empresas.empr_id_mysql) las
+ * funciones devuelven null/array vacío y lo dejan logueado: es un error de
+ * configuración del cliente, no un estado normal.
+ */
+
+if (!function_exists('tools_empr_id')) {
+    /**
+     * Devuelve el empr_id de tools para la empresa logueada en asset.
+     * Cachea en sesión ('tools_empr_id').
+     *
+     * @return int|null
+     */
+    function tools_empr_id()
+    {
+        $ci =& get_instance();
+
+        $cached = $ci->session->userdata('tools_empr_id');
+        if ($cached) {
+            return (int) $cached;
+        }
+
+        $userdata = $ci->session->userdata('user_data');
+        if (empty($userdata[0]['id_empresa'])) {
+            log_message('ERROR', '#TRAZA | ASSET | tools_helper | tools_empr_id() >> sin empresa en sesion');
+            return null;
+        }
+        $idAsset = $userdata[0]['id_empresa'];
+
+        $aux  = $ci->rest->callAPI('GET', REST_TOOLS_CORE . '/empresa/porAssetId/' . $idAsset);
+        $resp = json_decode($aux['data']);
+
+        if (empty($resp->empresa->empr_id)) {
+            log_message('ERROR', '#TRAZA | ASSET | tools_helper | tools_empr_id() >> empresa asset ' . $idAsset
+                . ' sin vinculo en tools (core.empresas.empr_id_mysql) — correr el setup del cliente');
+            return null;
+        }
+
+        $emprId = (int) $resp->empresa->empr_id;
+        $ci->session->set_userdata('tools_empr_id', $emprId);
+        return $emprId;
+    }
+}
+
+if (!function_exists('tools_config')) {
+    /**
+     * Lee la config por empresa registrada en el setup del cliente.
+     * Claves válidas: 'DEPO' (depósito único), 'PANO' (pañol único), 'ESTA' (establecimiento).
+     * Cachea en sesión ('tools_cfg_<clave>').
+     *
+     * @param  string $clave
+     * @return string|null  el id guardado, o null si falta config
+     */
+    function tools_config($clave)
+    {
+        $ci =& get_instance();
+
+        $cacheKey = 'tools_cfg_' . $clave;
+        $cached   = $ci->session->userdata($cacheKey);
+        if ($cached) {
+            return $cached;
+        }
+
+        $emprId = tools_empr_id();
+        if ($emprId === null) {
+            return null;
+        }
+
+        $aux  = $ci->rest->callAPI('GET', REST_TOOLS_CORE . '/tabla/ASSET/valor/' . $clave . '/empresa/' . $emprId);
+        $resp = json_decode($aux['data']);
+
+        if (empty($resp->configuracion->valor)) {
+            log_message('ERROR', '#TRAZA | ASSET | tools_helper | tools_config(' . $clave . ') >> sin config para empr_id '
+                . $emprId . ' — correr el paso 6 del setup del cliente');
+            return null;
+        }
+
+        $ci->session->set_userdata($cacheKey, $resp->configuracion->valor);
+        return $resp->configuracion->valor;
+    }
+}
+
+if (!function_exists('tools_articulos')) {
+    /**
+     * Catálogo de artículos de tools para la empresa logueada (getArticulos2).
+     * Cache por request (static). Devuelve array de arrays asociativos con las
+     * claves del DataService: id, barcode, titulo, descripcion, costo,
+     * cantidad_caja, punto_pedido, estado, unidad_medida, es_loteado, stock.
+     *
+     * @return array
+     */
+    function tools_articulos()
+    {
+        static $cache = null;
+        if ($cache !== null) {
+            return $cache;
+        }
+
+        $ci =& get_instance();
+
+        $emprId = tools_empr_id();
+        if ($emprId === null) {
+            return $cache = array();
+        }
+
+        $aux  = $ci->rest->callAPI('GET', REST_TOOLS_ALM . '/articulos/' . $emprId);
+        $resp = json_decode($aux['data'], true);
+
+        if (empty($resp['materias']['materia'])) {
+            return $cache = array();
+        }
+
+        $materias = $resp['materias']['materia'];
+        // El DataService devuelve un objeto (no una lista) cuando hay una sola fila.
+        if (isset($materias['id'])) {
+            $materias = array($materias);
+        }
+
+        return $cache = $materias;
+    }
+}
+
+if (!function_exists('tools_articulos_map')) {
+    /**
+     * Catálogo indexado por arti_id.
+     *
+     * @return array [arti_id => articulo]
+     */
+    function tools_articulos_map()
+    {
+        $map = array();
+        foreach (tools_articulos() as $a) {
+            $map[(int) $a['id']] = $a;
+        }
+        return $map;
+    }
+}
+
+if (!function_exists('tools_articulos_autocomplete')) {
+    /**
+     * Catálogo con el shape que esperan los autocompletes de asset
+     * (reemplaza a los SELECT sobre `articles`): value / codigo / label.
+     *
+     * @return array de objetos {value, codigo, label}
+     */
+    function tools_articulos_autocomplete()
+    {
+        $out = array();
+        foreach (tools_articulos() as $a) {
+            if (isset($a['estado']) && $a['estado'] === 'AN') {
+                continue;
+            }
+            $out[] = (object) array(
+                'value'  => (int) $a['id'],
+                'codigo' => $a['barcode'],
+                'label'  => $a['descripcion'],
+            );
+        }
+        usort($out, function ($x, $y) {
+            return strcasecmp($x->label, $y->label);
+        });
+        return $out;
+    }
+}
+
+if (!function_exists('tools_merge_articulos')) {
+    /**
+     * Completa filas locales de insumos (tbl_preventivoinsumos / tbl_predictivoinsumos /
+     * tbl_backloginsumos / tbl_otinsumos) con los datos del catálogo de tools,
+     * conservando las claves que las vistas de asset ya esperan
+     * (artBarCode, artDescription, id_empresa).
+     *
+     * @param  array $rows filas con al menos ['artId' => ...]
+     * @return array mismas filas + artBarCode / artDescription / id_empresa
+     */
+    function tools_merge_articulos($rows)
+    {
+        if (empty($rows)) {
+            return array();
+        }
+
+        $map    = tools_articulos_map();
+        $emprId = tools_empr_id();
+
+        foreach ($rows as &$r) {
+            $artId = isset($r['artId']) ? (int) $r['artId'] : 0;
+            if (isset($map[$artId])) {
+                $r['artBarCode']     = $map[$artId]['barcode'];
+                $r['artDescription'] = $map[$artId]['descripcion'];
+            } else {
+                // Referencia histórica a un id que no existe en el catálogo de tools
+                // (dato anterior al setup del cliente). Se muestra, no se oculta.
+                $r['artBarCode']     = '';
+                $r['artDescription'] = '(articulo ' . $artId . ' no disponible en tools)';
+            }
+            $r['id_empresa'] = $emprId;
+        }
+        unset($r);
+
+        return $rows;
+    }
+}

--- a/application/models/Backlogs.php
+++ b/application/models/Backlogs.php
@@ -219,31 +219,16 @@ class Backlogs extends CI_Model
 		}
 	}
 	// Trae insumos por id de preventivo para Editar
-	function getBacklogInsumos($id){
-			
-		$userdata = $this->session->userdata('user_data');
-		$empId = $userdata[0]['id_empresa']; 
-
-		$this->db->select('tbl_backloginsumos.id,
-												tbl_backloginsumos.cantidad,
-												articles.artBarCode,
-												articles.artId,
-												articles.artDescription,
-												articles.id_empresa');                            
-		$this->db->from('tbl_backloginsumos');
-		$this->db->join('articles', 'articles.artId = tbl_backloginsumos.artId');   
-		$this->db->where('tbl_backloginsumos.backId', $id);        
-		$this->db->where('articles.id_empresa', $empId);
-		$query= $this->db->get(); 
-
-		if( $query->num_rows() > 0)
-		{
-			return $query->result_array();
-		}
-		else {
-			return 0;
-		}
-	}
+    function getBacklogInsumos($id){
+        log_message('DEBUG', "#TRAZA | ASSET | Backlogs | getBacklogInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
+        $this->db->from('tbl_backloginsumos');
+        $this->db->where('backId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
+    }
   // Actualiza edicion de Backlog
  	function editar_backlogs($datos,$id_back){
  		$this->db->where('backId', $id_back);

--- a/application/models/Calendarios.php
+++ b/application/models/Calendarios.php
@@ -894,31 +894,16 @@ class Calendarios extends CI_Model {
             }
         }   
         // Trae insumos por id de preventivo para Editar
-        function getBacklogInsumos($id){
-                
-            $userdata = $this->session->userdata('user_data');
-            $empId = $userdata[0]['id_empresa']; 
-
-            $this->db->select('tbl_backloginsumos.id,
-                                                    tbl_backloginsumos.cantidad,
-                                                    articles.artBarCode,
-                                                    articles.artId,
-                                                    articles.artDescription,
-                                                    articles.id_empresa');                            
-            $this->db->from('tbl_backloginsumos');
-            $this->db->join('articles', 'articles.artId = tbl_backloginsumos.artId');   
-            $this->db->where('tbl_backloginsumos.backId', $id);        
-            $this->db->where('articles.id_empresa', $empId);
-            $query= $this->db->get(); 
-
-            if( $query->num_rows() > 0)
-            {
-                return $query->result_array();
-            }
-            else {
-                return 0;
-            }
-        }
+    function getBacklogInsumos($id){
+        log_message('DEBUG', "#TRAZA | ASSET | Calendarios | getBacklogInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
+        $this->db->from('tbl_backloginsumos');
+        $this->db->where('backId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
+    }
 
 
 
@@ -965,30 +950,15 @@ class Calendarios extends CI_Model {
         }
         // Trae insumos por id de preventivo para Editar
     function getPredictivoInsumos($id){
-        
-            $userdata = $this->session->userdata('user_data');
-            $empId = $userdata[0]['id_empresa']; 
-
-            $this->db->select('tbl_predictivoinsumos.id,
-                                                    tbl_predictivoinsumos.cantidad,
-                                                    articles.artBarCode,
-                                                    articles.artId,
-                                                    articles.artDescription,
-                                                    articles.id_empresa');                            
-            $this->db->from('tbl_predictivoinsumos');
-            $this->db->join('articles', 'articles.artId = tbl_predictivoinsumos.artId');   
-            $this->db->where('tbl_predictivoinsumos.predId', $id);        
-            $this->db->where('articles.id_empresa', $empId);
-            $query= $this->db->get(); 
-
-            if( $query->num_rows() > 0)
-            {
-                return $query->result_array();
-            }
-            else {
-                return 0;
-            }
-        }
+        log_message('DEBUG', "#TRAZA | ASSET | Calendarios | getPredictivoInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
+        $this->db->from('tbl_predictivoinsumos');
+        $this->db->where('predId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
+    }
         // Guarda el bacht de datos de herramientas 
         function insertOTHerram($idOT,$herra){
 
@@ -1056,31 +1026,16 @@ class Calendarios extends CI_Model {
             }
         }   
         // Trae insumos por id de preventivo para Editar
-        function getPreventivoInsumos($id){
-                
-            $userdata = $this->session->userdata('user_data');
-            $empId = $userdata[0]['id_empresa']; 
-
-            $this->db->select('tbl_preventivoinsumos.id,
-                                                    tbl_preventivoinsumos.cantidad,
-                                                    articles.artBarCode,
-                                                    articles.artId,
-                                                    articles.artDescription,
-                                                    articles.id_empresa');                            
-            $this->db->from('tbl_preventivoinsumos');
-            $this->db->join('articles', 'articles.artId = tbl_preventivoinsumos.artId');   
-            $this->db->where('tbl_preventivoinsumos.prevId', $id);        
-            $this->db->where('articles.id_empresa', $empId);
-            $query= $this->db->get(); 
-
-            if( $query->num_rows() > 0)
-            {
-                return $query->result_array();
-            }
-            else {
-                return 0;
-            }
-        }
+    function getPreventivoInsumos($id){
+        log_message('DEBUG', "#TRAZA | ASSET | Calendarios | getPreventivoInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
+        $this->db->from('tbl_preventivoinsumos');
+        $this->db->where('prevId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
+    }
     
 
         /**

--- a/application/models/Groups.php
+++ b/application/models/Groups.php
@@ -214,6 +214,8 @@ class Groups extends CI_Model {
 		$this->db->join('sismenuactions', 'sismenuactions.menuAccId = sisgroupsactions.menuAccId', 'inner');
 		$this->db->join('sismenu', 'sismenu.id = sismenuactions.menuId', 'inner');
 		//$this->db->where('sismenu.id_empresa', $empresaId);
+		// F3 (REQ-ASSET-ALM): honrar sismenu.estado — 'IN' inhabilita el item sin borrarlo
+		$this->db->where('sismenu.estado', 'AC');
 		$this->db->where('sisgroups.grpId', $grpId);
 		$this->db->group_by('sismenu.name');
 		$this->db->order_by("sismenu.id", "asc");
@@ -226,7 +228,8 @@ class Groups extends CI_Model {
 			if($m['parent'] != null){
 				if( array_search($m['parent'], array_column($all_menu, 'id')) !== false)
 				{
-				    $mnuParent = $this->db->get_where("sismenu", array('id' => $m['parent']) )->result_array();
+				    $mnuParent = $this->db->get_where("sismenu", array('id' => $m['parent'], 'estado' => 'AC') )->result_array();
+				    if (empty($mnuParent)) { continue; } // padre inhabilitado (F3)
 				    //array_push($mnuParent[0], $grpId);
 				    $mnuParent[0] += ['grpId' => $grpId];
 					$main_menu[] = $mnuParent[0];

--- a/application/models/Otrabajos.php
+++ b/application/models/Otrabajos.php
@@ -316,31 +316,16 @@ class Otrabajos extends CI_Model {
 			}
 		}
 		// Trae insumos por id de preventivo para Editar
-		function getOTInsumos($id){
-
-				$userdata = $this->session->userdata('user_data');
-				$empId = $userdata[0]['id_empresa']; 
-
-				$this->db->select('tbl_otinsumos.id,
-														tbl_otinsumos.cantidad,
-														articles.artBarCode,
-														articles.artId,
-														articles.artDescription,
-														articles.id_empresa');                            
-				$this->db->from('tbl_otinsumos');
-				$this->db->join('articles', 'articles.artId = tbl_otinsumos.artId');   
-				$this->db->where('tbl_otinsumos.otId', $id);        
-				$this->db->where('articles.id_empresa', $empId);
-				$query= $this->db->get(); 
-
-				if( $query->num_rows() > 0)
-				{
-					return $query->result_array();
-				}
-				else {
-					return 0;
-				}
-		}	
+    function getOTInsumos($id){
+        log_message('DEBUG', "#TRAZA | ASSET | Otrabajos | getOTInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
+        $this->db->from('tbl_otinsumos');
+        $this->db->where('otId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
+    }	
 		// Trae adjuntos de OT por id
 		function getOTadjuntos($id){
 			$this->db->select('tbl_otadjuntos.*');
@@ -1189,28 +1174,16 @@ class Otrabajos extends CI_Model {
 		    }
 
 		    // Trae insumos por id de preventivo para Editar
-		    function getPreventivoInsumos($id)
-		    {    
-		        $this->db->select('tbl_preventivoinsumos.id,
-		                            tbl_preventivoinsumos.cantidad,
-		                            articles.artBarCode,
-		                            articles.artId,
-		                            articles.artDescription,
-		                            articles.id_empresa');                            
-		        $this->db->from('tbl_preventivoinsumos');
-		        $this->db->join('articles', 'articles.artId = tbl_preventivoinsumos.artId');   
-		        $this->db->where('tbl_preventivoinsumos.prevId', $id);        
-		        $query= $this->db->get(); 
-
-		        if( $query->num_rows() > 0)
-		        {
-		          	$insumos = $query->result_array();
-		          	return $insumos;
-		        }
-		        else {
-		          return 0;
-		        }
-		    }
+    function getPreventivoInsumos($id){
+        log_message('DEBUG', "#TRAZA | ASSET | Otrabajos | getPreventivoInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
+        $this->db->from('tbl_preventivoinsumos');
+        $this->db->where('prevId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
+    }
 
 
 

--- a/application/models/Predictivos.php
+++ b/application/models/Predictivos.php
@@ -224,29 +224,14 @@ function updateAdjunto($adjunto,$ultimoId){
 
     // Trae insumos por id de preventivo para Editar
     function getPredictivoInsumos($id){
-        
-        $userdata = $this->session->userdata('user_data');
-        $empId = $userdata[0]['id_empresa']; 
-
-        $this->db->select('tbl_predictivoinsumos.id,
-                            tbl_predictivoinsumos.cantidad,
-                            articles.artBarCode,
-                            articles.artId,
-                            articles.artDescription,
-                            articles.id_empresa');                            
+        log_message('DEBUG', "#TRAZA | ASSET | Predictivos | getPredictivoInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
         $this->db->from('tbl_predictivoinsumos');
-        $this->db->join('articles', 'articles.artId = tbl_predictivoinsumos.artId');   
-        $this->db->where('tbl_predictivoinsumos.predId', $id);        
-        $this->db->where('articles.id_empresa', $empId);
-        $query= $this->db->get(); 
-
-        if( $query->num_rows() > 0)
-        {
-          return $query->result_array();
-        }
-        else {
-          return 0;
-        }
+        $this->db->where('predId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
     }
 
 	

--- a/application/models/Preventivos.php
+++ b/application/models/Preventivos.php
@@ -236,42 +236,35 @@ class Preventivos extends CI_Model
 
 	//Trae insumos (articles) por empresa logueada
 	function getinsumo(){
-		$userdata = $this->session->userdata('user_data');
-			$empId = $userdata[0]['id_empresa'];
-			$this->db->select('articles.artId AS value, 
-												articles.artBarCode AS codigo,
-												articles.artDescription AS label');
-			$this->db->from('articles');      
-			$this->db->where('articles.id_empresa', $empId);
-			$this->db->where('articles.artEstado !=', 'AN');
-			$this->db->order_by('label', 'ASC');
-			$query = $this->db->get();		
-		if($query->num_rows()>0){
-			return $query->result();
-		}
-		else{
-			return false;
-		}
+		log_message('DEBUG', "#TRAZA | ASSET | Preventivos | getinsumo()");
+		// F3 (REQ-ASSET-ALM): el catalogo de articulos vive en tools, no en `articles`.
+		$this->load->helper('tools');
+		return tools_articulos_autocomplete();
 	}
 
 	//Trae insumo por id
 	function traerinsumo($data = null){
-		$id = $data['id_insumo'];
-		$userdata = $this->session->userdata('user_data');
-        $empId = $userdata[0]['id_empresa']; 
-
-        $this->db->select('articles.*');
-    	$this->db->from('articles');    	
-    	$this->db->where('articles.artId', $id);    	
-    	$this->db->where('articles.id_empresa', $empId);
-
-    	$query= $this->db->get();
-    	if($query->num_rows()>0){
-                return $query->result();
-       	}
-        else{
-                return false;
-        }	
+		log_message('DEBUG', "#TRAZA | ASSET | Preventivos | traerinsumo()");
+		// F3 (REQ-ASSET-ALM): el articulo se resuelve contra el catalogo de tools.
+		if ($data == null || empty($data['id_insumo'])) {
+			return false;
+		}
+		$this->load->helper('tools');
+		$map = tools_articulos_map();
+		$id  = (int) $data['id_insumo'];
+		if (!isset($map[$id])) {
+			return false;
+		}
+		$a = $map[$id];
+		return array((object) array(
+			'artId'          => (int) $a['id'],
+			'artBarCode'     => $a['barcode'],
+			'artDescription' => $a['descripcion'],
+			'artCoste'       => $a['costo'],
+			'punto_pedido'   => $a['punto_pedido'],
+			'unidadmedida'   => $a['unidad_medida'],
+			'id_empresa'     => tools_empr_id(),
+		));
 	}
 
 	// Guarda Preventivo 
@@ -381,29 +374,14 @@ class Preventivos extends CI_Model
 
     // Trae insumos por id de preventivo para Editar
     function getPreventivoInsumos($id){
-        
-        $userdata = $this->session->userdata('user_data');
-        $empId = $userdata[0]['id_empresa']; 
-
-        $this->db->select('tbl_preventivoinsumos.id,
-                            tbl_preventivoinsumos.cantidad,
-                            articles.artBarCode,
-                            articles.artId,
-                            articles.artDescription,
-                            articles.id_empresa');                            
+        log_message('DEBUG', "#TRAZA | ASSET | Preventivos | getPreventivoInsumos()");
+        // F3 (REQ-ASSET-ALM): el detalle local se conserva en MariaDB; los datos
+        // del articulo salen del catalogo de tools via REST (tools_helper).
+        $this->load->helper('tools');
+        $this->db->select('id, cantidad, artId');
         $this->db->from('tbl_preventivoinsumos');
-        $this->db->join('articles', 'articles.artId = tbl_preventivoinsumos.artId');   
-        $this->db->where('tbl_preventivoinsumos.prevId', $id);        
-        $this->db->where('articles.id_empresa', $empId);
-        $query= $this->db->get(); 
-
-        if( $query->num_rows() > 0)
-        {
-          return $query->result_array();
-        }
-        else {
-          return 0;
-        }
+        $this->db->where('prevId', $id);
+        return tools_merge_articulos($this->db->get()->result_array());
     }
 
     // Guarda edicion de Preventivo 

--- a/database/scripts/f3-inhabilitar-menu-almacen.sql
+++ b/database/scripts/f3-inhabilitar-menu-almacen.sql
@@ -1,0 +1,33 @@
+-- F3 (REQ-ASSET-ALM): inhabilitar las opciones de menú de almacén en AssetPlanner.
+--
+-- Qué hace: marca estado='IN' en los ítems de sismenu del almacén propio de asset
+-- (viejo y embebido). NO borra filas — revertir es volver a 'AC'.
+-- Requiere el código de F3 desplegado: Groups::mnuAll() filtra por estado a partir
+-- de esa fase (antes, la columna estado no se consultaba y este script no tendría efecto).
+--
+-- Dónde se ejecuta: manualmente con mysql contra la base assetv2 del ambiente
+-- (DEV 10.142.0.13:3306), DESPUÉS de desplegar el código de F3:
+--   mysql -h <host> -u <user> -p assetv2 < f3-inhabilitar-menu-almacen.sql
+--
+-- Ítems (ids relevados en DEV el 2026-08-14 — verificar con el SELECT de abajo
+-- antes de correr en otro ambiente, los ids podrían diferir):
+--   59 Almacenes (grupo)            73 Ajuste Stock           76 Recep. Deposito
+--   77 Salida Deposito              44 Compras (grupo)        46 Recepción pedidos
+--   41 Administrar Ordenes (Envio)  34 ABM Deposito           72 ABM Plantilla Insumos
+--   37 ABM Proveedor                61 Rep articulos pedidos
+--
+-- El grupo Pañol (16) y sus hijos NO se tocan acá: eso es la fase F4.
+
+-- Verificación previa (los nombres deben coincidir con la lista de arriba):
+SELECT id, parent, name, slug, estado FROM sismenu
+ WHERE id IN (34, 37, 41, 44, 46, 59, 61, 72, 73, 76, 77);
+
+UPDATE sismenu SET estado = 'IN'
+ WHERE id IN (34, 37, 41, 44, 46, 59, 61, 72, 73, 76, 77);
+
+-- Verificación posterior (debe devolver 11 filas, todas 'IN'):
+SELECT id, name, estado FROM sismenu
+ WHERE id IN (34, 37, 41, 44, 46, 59, 61, 72, 73, 76, 77);
+
+-- Reversa (si hace falta volver atrás):
+-- UPDATE sismenu SET estado = 'AC' WHERE id IN (34, 37, 41, 44, 46, 59, 61, 72, 73, 76, 77);

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -9,7 +9,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 ---
 
 **Workstream actual:** Requerimiento "asset consume ALM+PAN de tools" (cliente en el corto plazo) — adelanta la Etapa 5 del plan de migración.
-**Última actualización:** 2026-08-12 por Claude Code (F0: metodología y fundaciones).
+**Última actualización:** 2026-08-14 por Claude Code (F0 mergeada; F1 completada y en PR en traz-tools).
 
 ### Fases del plan y su estado
 
@@ -17,8 +17,8 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 | Fase | Descripción | Repo donde se ejecuta | Clase | Estado | Rama / PR |
 |---|---|---|---|---|---|
-| F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE, branch protection pendiente de configurar en GitHub (Settings → Branches, requiere PR + no bypass) | asset | 🟢 | **En PR** | `docs/e0-metodologia-v3` |
-| F1 | Sincronizar `ALMDataService` EI←MI (fix aislamiento + parametrización de `getArticulos2` y revisión de las demás queries divergentes) + crear query `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + índice/unicidad de `empr_id_mysql` | **traz-tools** | 🟡 | Pendiente — **bloquea F3-F5** | — |
+| F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE | asset | 🟢 | **Mergeada** (branch protection de `develop-v3` configurada por Rodolfo el 2026-08-14) | PR #322 |
+| F1 | Sincronizar `ALMDataService` EI←MI + `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + migración formal de `empr_id_mysql` | **traz-tools** | 🟡 | **Completada, en PR (bloquea F3-F5 hasta el merge).** 84 queries idénticas en ambas copias; fix de aislamiento en las 3 queries de artículos verificado contra Postgres DEV (empresa 87: 7.534 → 4.532 de stock); lookup probado (match y no-match); `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` idempotente, **aplicación manual pendiente en TEST/PROD**; CAR del MI buildea con los fixes. El hardcode `empr_id = 1` de la copia EI quedó eliminado | traz-tools PR #426 (mergear después del #425) |
 | F2 | Checklist de setup por cliente: verificar vínculo `empr_id_mysql`, crear establecimiento + "Depósito \<empresa\>" + "Pañol \<empresa\>" en tools, cargar catálogo del cliente (Caleras: 32 artículos, 2 herramientas), registrar `empr_id`/`depo_id`/`pano_id` en config de asset. Documento autocontenido con DÓNDE se ejecuta cada paso | asset (doc) + manual | 🟢 | Pendiente | — |
 | F3 | Asset almacén → tools: inhabilitar menús de almacén en `sismenu`; models de almacén de SQL a REST (`REST.php` → `ALMDataService`); resolución de `empr_id` tools en sesión | asset | 🟡 | Pendiente — requiere F1 | — |
 | F4 | Asset herramientas → tools: ídem contra `PANDataservice`; autocompletes de herramientas en planes/OTs consumen REST; definir tratamiento de las 10 referencias históricas de Caleras en `tbl_otherramientas` (remapeo manual o histórico de solo lectura) | asset | 🟡 | Pendiente — requiere F1 | — |
@@ -27,9 +27,9 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 ### Próxima acción
 
-1. Aprobar y mergear el PR de F0; configurar branch protection de `develop-v3` en GitHub (manual, Rodolfo).
-2. Arrancar F1 en `traz-tools` (es prerrequisito de todo lo demás): sincronización EI←MI de `ALMDataService` + `getEmpresaByMysqlId`. Sale de rama en traz-tools, PR a su `develop-v3`.
-3. En paralelo puede escribirse el checklist de F2 (doc, no bloquea ni se bloquea).
+1. Aprobar y mergear en `traz-tools`: **#425** (landeo del registro REQ-ASSET-ALM que quedó huérfano tras el merge de #424) y después **#426** (F1).
+2. Rodolfo: aplicar `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` a mano en TEST cuando corresponda (DEV ya verificado sin duplicados).
+3. Escribir el checklist de F2 (doc, no depende de F1) y arrancar F3 en este repo apenas #426 esté mergeado.
 
 ### Decisiones recientes (últimas 5)
 
@@ -43,6 +43,5 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 ### Bloqueos
 
-- **F1 bloquea F3, F4 y F5.** Sin la sincronización EI←MI, asset consumiría queries con `empr_id=1` hardcodeado.
-- **Branch protection de `develop-v3` en este repo**: pendiente de configurar en GitHub (solo Rodolfo tiene admin).
-- Heredados de tools (informativos): `empr_id_mysql` sin migración formal; credenciales legacy en configs de ambos repos pendientes de rotación (inventariadas en el plan de migración).
+- **F1 en PR (traz-tools #426) — F3-F5 siguen bloqueadas hasta su merge.** El hardcode `empr_id=1` ya está corregido en la rama.
+- Heredados de tools (informativos): la migración formal de `empr_id_mysql` ya existe como script (F1) pero falta aplicarla en TEST/PROD; credenciales legacy en configs de ambos repos pendientes de rotación (inventariadas en el plan de migración).

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -9,7 +9,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 ---
 
 **Workstream actual:** Requerimiento "asset consume ALM+PAN de tools" (cliente en el corto plazo) — adelanta la Etapa 5 del plan de migración.
-**Última actualización:** 2026-08-14 por Claude Code (F0 mergeada; F1 completada y en PR en traz-tools).
+**Última actualización:** 2026-08-14 por Claude Code (F2: checklist de setup por cliente, en PR).
 
 ### Fases del plan y su estado
 
@@ -19,7 +19,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 |---|---|---|---|---|---|
 | F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE | asset | 🟢 | **Mergeada** (branch protection de `develop-v3` configurada por Rodolfo el 2026-08-14) | PR #322 |
 | F1 | Sincronizar `ALMDataService` EI←MI + `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + migración formal de `empr_id_mysql` | **traz-tools** | 🟡 | **Completada, en PR (bloquea F3-F5 hasta el merge).** 84 queries idénticas en ambas copias; fix de aislamiento en las 3 queries de artículos verificado contra Postgres DEV (empresa 87: 7.534 → 4.532 de stock); lookup probado (match y no-match); `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` idempotente, **aplicación manual pendiente en TEST/PROD**; CAR del MI buildea con los fixes. El hardcode `empr_id = 1` de la copia EI quedó eliminado | traz-tools PR #426 (mergear después del #425) |
-| F2 | Checklist de setup por cliente: verificar vínculo `empr_id_mysql`, crear establecimiento + "Depósito \<empresa\>" + "Pañol \<empresa\>" en tools, cargar catálogo del cliente (Caleras: 32 artículos, 2 herramientas), registrar `empr_id`/`depo_id`/`pano_id` en config de asset. Documento autocontenido con DÓNDE se ejecuta cada paso | asset (doc) + manual | 🟢 | Pendiente | — |
+| F2 | Checklist de setup por cliente | asset (doc) + manual | 🟢 | **Completada, en PR.** `doc/v3/setup-cliente-alm-pan.md`: 8 pasos autocontenidos (vínculo de empresa, usuarios Dnato/Bonita, establecimiento, depósito, pañol, config, catálogo, verificación end-to-end), cada uno con DÓNDE se ejecuta, comando y verificación. Decisión técnica tomada: **la config por empresa (`DEPO_ID`/`PANO_ID`/`ESTA_ID`) vive en `core.tablas` de tools** (clave `ASSET`+`DEPO`/`PANO`/`ESTA`, vía `setTabla`/`getTablaValorXEmp` — el trigger `set_tabla_id_bui` arma la clave), NO en el esquema congelado de asset. Contratos verificados contra los `.dbs` y las bases de DEV (columnas reales de `articles`/`herramientas`, trigger de `core.tablas`, seriales). **La ejecución manual del checklist para el primer cliente queda pendiente** (requiere F1 desplegada) | `docs/f2-checklist-setup-cliente` — PR abierto |
 | F3 | Asset almacén → tools: inhabilitar menús de almacén en `sismenu`; models de almacén de SQL a REST (`REST.php` → `ALMDataService`); resolución de `empr_id` tools en sesión | asset | 🟡 | Pendiente — requiere F1 | — |
 | F4 | Asset herramientas → tools: ídem contra `PANDataservice`; autocompletes de herramientas en planes/OTs consumen REST; definir tratamiento de las 10 referencias históricas de Caleras en `tbl_otherramientas` (remapeo manual o histórico de solo lectura) | asset | 🟡 | Pendiente — requiere F1 | — |
 | F5 | Flujo ejecutar-OT: pedido de materiales vía REST contra el mismo Bonita (`Calendario.php:632-646`, `Tarea.php:684`, `view_OtEjecutar_modal.php`); pantallas de visualización de almacén → tools | asset | 🟡 | Pendiente — requiere F3 | — |
@@ -29,17 +29,18 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 1. Aprobar y mergear en `traz-tools`: **#425** (landeo del registro REQ-ASSET-ALM que quedó huérfano tras el merge de #424) y después **#426** (F1).
 2. Rodolfo: aplicar `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` a mano en TEST cuando corresponda (DEV ya verificado sin duplicados).
-3. Escribir el checklist de F2 (doc, no depende de F1) y arrancar F3 en este repo apenas #426 esté mergeado.
+3. Ejecutar el checklist de F2 (`doc/v3/setup-cliente-alm-pan.md`) para el cliente del requerimiento, una vez que F1 esté desplegada en el ambiente.
+4. Arrancar F3 en este repo apenas #426 esté mergeado — el código de F3 lee la config con la clave `ASSET`+`DEPO`/`PANO`/`ESTA` definida en el checklist.
 
 ### Decisiones recientes (últimas 5)
 
 | Fecha | Decisión | Referencia |
 |---|---|---|
+| 2026-08-14 | **La config por empresa que asset necesita en runtime (`DEPO_ID`/`PANO_ID`/`ESTA_ID`) se guarda en `core.tablas` de tools, no en asset.** Razones: el esquema de `assetv2` está congelado (D10), `core.tablas` ya soporta valores por empresa (`empr_id` + trigger `set_tabla_id_bui` que arma la clave) y tiene lectura/escritura REST existentes (`getTablaValorXEmp`/`setTabla`). Convención: tabla `ASSET`, valores `DEPO`/`PANO`/`ESTA`, el id viaja en `descripcion`. Decisión técnica menor tomada en F2 — F3 debe leer con esa clave | `doc/v3/setup-cliente-alm-pan.md` paso 6 |
 | 2026-08-12 | **Verificación en producción completada (read-only): almacén operativo de asset en CERO absoluto** (pedidos, remitos, órdenes de insumos, lotes, envíos: 0 filas). Catálogos con uso mínimo: el único cliente real con datos es Caleras San Juan (32 artículos, 2 herramientas, 10 refs históricas en `tbl_otherramientas`); el resto es de empresas de prueba. Habilita D2 y D7: reemplazo sin migración masiva, con carga manual del catálogo de Caleras en el setup | CONTEXT-PACK §3, script `verify-asset-herr-alm-usage.sh` (scratchpad de la sesión) |
 | 2026-08-12 | **Encontrado el gotcha que bloquea consumir ALM hoy: la copia EI de `ALMDataService.dbs` tiene `getArticulos2` con `WHERE A.empr_id = 1` hardcodeado y sin el fix de aislamiento** del 2026-08-11 (que está solo en la copia MI). La sincronización EI←MI pasa de "mejora pendiente" a prerrequisito (F1) | CONTEXT-PACK §4 |
 | 2026-08-12 | **No existe lookup inverso `empr_id_mysql → empr_id`**: la registración freemium escribe el vínculo solo en `core.empresas.empr_id_mysql` (el INSERT en assetv2 no guarda nada de tools). Hay que crear `getEmpresaByMysqlId` en `COREDataService` (F1). La columna además no es única ni está indexada, y sigue sin migración SQL formal | `COREDataService.dbs:379-405` |
 | 2026-08-12 | **`develop-v3` creada en este repo desde `develop`** (que está contenida en `master`; master solo suma los 16 merges de tags `v2.9.x`). Todo el trabajo v3 entra por PR contra ella, un PR por fase | D1, CLAUDE.md |
-| 2026-08-12 | **Requerimiento aprobado por el PM con 7 respuestas clave**: puente de empresas por lookup REST (no tocar esquema asset), depósito por id resuelto en setup, unificación EI↔MI progresiva, DataServices como bus interno sin validación por usuario para acceso por id, mismo Bonita, inhabilitar (no borrar) menús, y excepción explícita al freeze | CONTEXT-PACK §2 (D1-D10) |
 
 ### Bloqueos
 

--- a/doc/v3/STATE.md
+++ b/doc/v3/STATE.md
@@ -9,7 +9,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 ---
 
 **Workstream actual:** Requerimiento "asset consume ALM+PAN de tools" (cliente en el corto plazo) — adelanta la Etapa 5 del plan de migración.
-**Última actualización:** 2026-08-14 por Claude Code (F2: checklist de setup por cliente, en PR).
+**Última actualización:** 2026-08-14 por Claude Code (F3: almacén de asset → REST, en PR).
 
 ### Fases del plan y su estado
 
@@ -20,7 +20,7 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 | F0 | Metodología y fundaciones: `develop-v3` creada, CLAUDE.md + CONTEXT-PACK + STATE | asset | 🟢 | **Mergeada** (branch protection de `develop-v3` configurada por Rodolfo el 2026-08-14) | PR #322 |
 | F1 | Sincronizar `ALMDataService` EI←MI + `getEmpresaByMysqlId` en `COREDataService` (ambas copias) + migración formal de `empr_id_mysql` | **traz-tools** | 🟡 | **Completada, en PR (bloquea F3-F5 hasta el merge).** 84 queries idénticas en ambas copias; fix de aislamiento en las 3 queries de artículos verificado contra Postgres DEV (empresa 87: 7.534 → 4.532 de stock); lookup probado (match y no-match); `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` idempotente, **aplicación manual pendiente en TEST/PROD**; CAR del MI buildea con los fixes. El hardcode `empr_id = 1` de la copia EI quedó eliminado | traz-tools PR #426 (mergear después del #425) |
 | F2 | Checklist de setup por cliente | asset (doc) + manual | 🟢 | **Completada, en PR.** `doc/v3/setup-cliente-alm-pan.md`: 8 pasos autocontenidos (vínculo de empresa, usuarios Dnato/Bonita, establecimiento, depósito, pañol, config, catálogo, verificación end-to-end), cada uno con DÓNDE se ejecuta, comando y verificación. Decisión técnica tomada: **la config por empresa (`DEPO_ID`/`PANO_ID`/`ESTA_ID`) vive en `core.tablas` de tools** (clave `ASSET`+`DEPO`/`PANO`/`ESTA`, vía `setTabla`/`getTablaValorXEmp` — el trigger `set_tabla_id_bui` arma la clave), NO en el esquema congelado de asset. Contratos verificados contra los `.dbs` y las bases de DEV (columnas reales de `articles`/`herramientas`, trigger de `core.tablas`, seriales). **La ejecución manual del checklist para el primer cliente queda pendiente** (requiere F1 desplegada) | `docs/f2-checklist-setup-cliente` — PR abierto |
-| F3 | Asset almacén → tools: inhabilitar menús de almacén en `sismenu`; models de almacén de SQL a REST (`REST.php` → `ALMDataService`); resolución de `empr_id` tools en sesión | asset | 🟡 | Pendiente — requiere F1 | — |
+| F3 | Asset almacén → tools | asset | 🟡 | **Completada, en PR.** Nuevo `application/helpers/tools_helper.php` (lookup `tools_empr_id()` cacheado en sesión, `tools_config()` con la clave `ASSET`+`DEPO`/`PANO`/`ESTA`, catálogo con cache por request) + constantes `REST_TOOLS_*`. Los 9 puntos del núcleo que leían `articles` pasaron a REST conservando el shape de salida (autocomplete `getinsumo`, `traerinsumo`, y los 7 getters gemelos `getXInsumos` de Preventivos/Predictivos/Backlogs/Otrabajos/Calendarios — el detalle `tbl_*insumos` sigue local, sólo el catálogo va a tools). Menú: `Groups::mnuAll()` ahora honra `sismenu.estado` (antes la columna no se consultaba) + script `database/scripts/f3-inhabilitar-menu-almacen.sql` (11 ítems a `IN`, reversible). Hallazgo del relevamiento: **assetv2 tiene un espejo local de las tablas `alm_*` de tools** (port embebido del módulo de almacenes) con 107 pedidos, todos de empresas de prueba (el último de 2024) — el supuesto D2 se sostiene; ese espejo se abandona en F5. `agregar_insumo` (alta on-the-fly) quedó fuera: ya estaba rota en producción (llama a un model sin cargar) y el alta pasa a pantallas de tools. **Smoke de runtime pendiente de que se redeployen los `.dbs` de F1 en el EI de DEV** (verificado: el EI de DEV aún sirve la versión vieja) | `feat/f3-almacen-rest` — PR abierto |
 | F4 | Asset herramientas → tools: ídem contra `PANDataservice`; autocompletes de herramientas en planes/OTs consumen REST; definir tratamiento de las 10 referencias históricas de Caleras en `tbl_otherramientas` (remapeo manual o histórico de solo lectura) | asset | 🟡 | Pendiente — requiere F1 | — |
 | F5 | Flujo ejecutar-OT: pedido de materiales vía REST contra el mismo Bonita (`Calendario.php:632-646`, `Tarea.php:684`, `view_OtEjecutar_modal.php`); pantallas de visualización de almacén → tools | asset | 🟡 | Pendiente — requiere F3 | — |
 | F6 | Prueba integral en DEV + piloto con el cliente del requerimiento | ambos | 🟡 | Pendiente — requiere F2-F5 | — |
@@ -29,8 +29,10 @@ Tablero de estado del trabajo v3 en ESTE repo (integración con traz-tools: alma
 
 1. Aprobar y mergear en `traz-tools`: **#425** (landeo del registro REQ-ASSET-ALM que quedó huérfano tras el merge de #424) y después **#426** (F1).
 2. Rodolfo: aplicar `scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` a mano en TEST cuando corresponda (DEV ya verificado sin duplicados).
-3. Ejecutar el checklist de F2 (`doc/v3/setup-cliente-alm-pan.md`) para el cliente del requerimiento, una vez que F1 esté desplegada en el ambiente.
-4. Arrancar F3 en este repo apenas #426 esté mergeado — el código de F3 lee la config con la clave `ASSET`+`DEPO`/`PANO`/`ESTA` definida en el checklist.
+3. **Rodolfo: redeployar los `.dbs` de F1 en el EI de DEV** (copiar `ALMDataService.dbs`/`COREDataService.dbs` de `traz-tools/_backend/api/dataservice/` al deployment del EI) — verificado que DEV sigue sirviendo la versión vieja; sin esto no hay smoke de F3 ni ejecución de F2.
+4. Ejecutar el checklist de F2 (`doc/v3/setup-cliente-alm-pan.md`) para el cliente del requerimiento.
+5. Aplicar `database/scripts/f3-inhabilitar-menu-almacen.sql` en DEV después de desplegar el código de F3.
+6. Arrancar F4 (herramientas → `PANDataservice`): el relevamiento ya identificó sus funciones (`getHerramientasB`, `getProductos`, model `Herramientas.php`, menú Pañol).
 
 ### Decisiones recientes (últimas 5)
 

--- a/doc/v3/setup-cliente-alm-pan.md
+++ b/doc/v3/setup-cliente-alm-pan.md
@@ -1,0 +1,220 @@
+# Setup de un cliente de AssetPlanner para consumir Almacén y Pañol de traz-tools
+
+## Objetivo
+
+Checklist para configurar a mano, una vez por cliente, todo lo que AssetPlanner necesita del lado de traz-tools antes de que ese cliente use el almacén (`traz-comp-almacenes`) y el pañol (`traz-comp-pan`) de tools: empresa vinculada, establecimiento, depósito único, pañol único, catálogo inicial y config por empresa. Lo ejecuta quien haga el onboarding (hoy Rodolfo), completo y en orden — cada paso dice DÓNDE se ejecuta. **No cubre** los cambios de código de asset (fases F3-F5, ver `STATE.md`) ni el alta de la infraestructura WSO2 (ver `traz-tools/doc/infra/`).
+
+---
+
+**Prerrequisitos (verificar antes de arrancar):**
+
+1. **F1 mergeada Y desplegada** en el WSO2 del ambiente: el CAR/artefactos con la sincronización de `ALMDataService` y el lookup `getEmpresaByMysqlId` (traz-tools PR #426). Sin esto, las verificaciones REST de este checklist fallan con 404 o devuelven datos de la empresa 1.
+2. **Migración `empr_id_mysql` aplicada** en el PostgreSQL del ambiente: `traz-tools/scripts/sql/2026-08-core-empresas-empr-id-mysql.sql` (idempotente; en DEV ya está verificada).
+3. Acceso de red al ambiente (VPN para DEV) y credenciales de las bases.
+
+**Endpoints por ambiente** (usar el que corresponda en TODOS los pasos; los ejemplos de este doc usan DEV):
+
+| Qué | DEV | PROD (completar cuando exista) |
+|---|---|---|
+| WSO2 EI (DataServices) | `http://10.142.0.13:8280/services` | — |
+| PostgreSQL tools | `10.142.0.13:5432`, base `tools_prod_t` | — |
+| MariaDB assetv2 | `10.142.0.13:3306`, base `assetv2` | — |
+| App tools (pantallas) | según ambiente | — |
+
+**Convenciones de nombres (decisión D3/D7):** el depósito se llama `Depósito <NombreEmpresa>` y el pañol `Pañol <NombreEmpresa>`. El nombre es para humanos; **el runtime usa SIEMPRE los ids** (`depo_id`, `pano_id`) que este checklist deja registrados en el paso 6.
+
+---
+
+## Datos de entrada (completar antes de empezar)
+
+| Dato | Valor |
+|---|---|
+| Nombre de la empresa | |
+| `id_empresa` en assetv2 (MariaDB) | |
+| CUIT | |
+| Usuarios que van a operar pantallas de tools (nombre + email) | |
+
+---
+
+## Paso 1 — Vincular la empresa (assetv2 ↔ tools)
+
+**Dónde: terminal con `psql` contra el PostgreSQL de tools del ambiente.**
+
+1. Verificar si la empresa ya está vinculada:
+
+   ```sql
+   SELECT empr_id, nombre, descripcion, empr_id_mysql FROM core.empresas WHERE empr_id_mysql = <ID_ASSET>;
+   ```
+
+   - **Devuelve una fila** → vinculada. Anotar el `empr_id` y saltar al paso 2.
+   - **Vacío** → seguir.
+
+2. Verificar si la empresa existe en tools sin vínculo (buscar por nombre/CUIT):
+
+   ```sql
+   SELECT empr_id, nombre, cuit, empr_id_mysql FROM core.empresas WHERE eliminado IS NOT TRUE AND (nombre ILIKE '%<parte del nombre>%' OR cuit = '<CUIT>');
+   ```
+
+   - **Existe** → vincular: `UPDATE core.empresas SET empr_id_mysql = <ID_ASSET> WHERE empr_id = <EMPR_ID>;`
+   - **No existe** → crearla y vincularla en un paso (los demás campos se completan después desde las pantallas de tools si hace falta):
+
+   ```sql
+   INSERT INTO core.empresas (nombre, descripcion, cuit, empr_id_mysql) VALUES ('<NombreEmpresa>', '<NombreEmpresa>', '<CUIT>', <ID_ASSET>) RETURNING empr_id;
+   ```
+
+3. **Verificación (obligatoria)** — desde una terminal con acceso al WSO2 del ambiente, probar el lookup que va a usar asset en runtime:
+
+   ```bash
+   curl -s http://10.142.0.13:8280/services/COREDataService/empresa/porAssetId/<ID_ASSET>
+   ```
+
+   Debe devolver `{"empresa":{"empr_id":"<EMPR_ID>","descripcion":"..."}}`. Si devuelve vacío o 404, no seguir: o falta el deploy de F1 o el UPDATE no se aplicó.
+
+> ⚠️ La unicidad importa: un `id_empresa` de asset no puede apuntar a dos empresas de tools. El índice único del prerrequisito 2 lo garantiza — si el UPDATE falla por duplicado, hay una inconsistencia previa que resolver antes de seguir.
+
+**Anotar: `EMPR_ID` = ______**
+
+---
+
+## Paso 2 — Acceso de los usuarios a las pantallas de tools
+
+Los usuarios del cliente van a ver las pantallas de almacén y pañol **en tools**, no en asset (decisión del requerimiento, punto 5). Necesitan poder loguearse en tools.
+
+**Dónde: portal de Dnato del ambiente (alta de usuarios) + portal de Bonita si falta el grupo.**
+
+1. Dar de alta los usuarios del cliente en Dnato, asociados a la empresa `EMPR_ID`.
+2. **Verificación**: loguearse en la app de tools con uno de esos usuarios. Debe entrar y ver el menú.
+3. Si el login funciona pero el menú sale vacío o fallan las bandejas: falta el grupo de Bonita de la empresa (formato `{empr_id}-{nombre}`, ej. `9000-Termotanques` — ver `traz-tools/doc/v3/deployment-gcp.md` §7.0-quater). Crearlo en el portal de Bonita del ambiente y reintentar.
+
+> Nota: si la empresa se creó por la registración freemium, esto ya existe. El caso manual del paso 1.2 es el que puede requerir crear el grupo a mano.
+
+---
+
+## Paso 3 — Establecimiento
+
+El depósito y el pañol cuelgan de un establecimiento (`prd.establecimientos`), así que va primero.
+
+**Dónde: terminal con `curl` contra el WSO2 del ambiente.**
+
+```bash
+curl -s -X POST http://10.142.0.13:8280/services/ALMDataService/establecimientos -H "Content-Type: application/json" -d '{"nombre":"<NombreEmpresa>","longitud":"","latitud":"","calles":"","altura":"","localidad":"","pais":"Argentina","usuario":"setup","empr_id":"<EMPR_ID>"}'
+```
+
+**Verificación** (psql): `SELECT esta_id, nombre FROM prd.establecimientos WHERE empr_id = <EMPR_ID>;`
+
+Alternativa por pantalla: app de tools → módulo Producción → Establecimientos (controller `traz-prod-trazasoft/general/Establecimiento.php`).
+
+**Anotar: `ESTA_ID` = ______**
+
+---
+
+## Paso 4 — Depósito único "Depósito \<NombreEmpresa\>"
+
+No hay pantalla ni query de alta de depósito en `ALMDataService` — se crea por SQL.
+
+**Dónde: terminal con `psql` contra el PostgreSQL de tools del ambiente.**
+
+```sql
+INSERT INTO alm.alm_depositos (descripcion, nombre, esta_id, empr_id, estado, eliminado) VALUES ('Depósito <NombreEmpresa>', 'Depósito <NombreEmpresa>', <ESTA_ID>, <EMPR_ID>, 'AC', false) RETURNING depo_id;
+```
+
+**Verificación** (curl — es la misma consulta que va a usar asset):
+
+```bash
+curl -s http://10.142.0.13:8280/services/ALMDataService/mcp/depositos/<EMPR_ID>
+```
+
+Debe listar el depósito recién creado con su `depo_id` y el establecimiento.
+
+**Anotar: `DEPO_ID` = ______**
+
+---
+
+## Paso 5 — Pañol único "Pañol \<NombreEmpresa\>"
+
+El pañol no tiene ABM en pantalla — se crea por REST contra `PANDataservice`.
+
+**Dónde: terminal con `curl` contra el WSO2 del ambiente.**
+
+```bash
+curl -s -X POST http://10.142.0.13:8280/services/PANDataservice/panol -H "Content-Type: application/json" -d '{"descripcion":"Pañol <NombreEmpresa>","usuario_app":"setup","empr_id":"<EMPR_ID>","esta_id":"<ESTA_ID>","nombre":"Pañol <NombreEmpresa>"}'
+```
+
+Devuelve `{"respuesta":{"pano_id":"<PANO_ID>"}}`.
+
+**Verificación**: `curl -s http://10.142.0.13:8280/services/PANDataservice/panol/empresa/<EMPR_ID>`
+
+**Anotar: `PANO_ID` = ______**
+
+---
+
+## Paso 6 — Registrar la config por empresa (la que va a leer asset)
+
+Los tres ids quedan guardados en `core.tablas` (tabla genérica clave-valor de tools, con soporte por empresa — el trigger `set_tabla_id_bui` arma la clave). Es lo que F3 va a leer en runtime en lugar de resolver nada por nombre.
+
+**Dónde: terminal con `curl` contra el WSO2 del ambiente.** Un POST por id:
+
+```bash
+curl -s -X POST http://10.142.0.13:8280/services/COREDataService/tablas -H "Content-Type: application/json" -d '{"tabla":"ASSET","valor":"DEPO","valor2":"","valor3":"","descripcion":"<DEPO_ID>","empr_id":"<EMPR_ID>"}'
+curl -s -X POST http://10.142.0.13:8280/services/COREDataService/tablas -H "Content-Type: application/json" -d '{"tabla":"ASSET","valor":"PANO","valor2":"","valor3":"","descripcion":"<PANO_ID>","empr_id":"<EMPR_ID>"}'
+curl -s -X POST http://10.142.0.13:8280/services/COREDataService/tablas -H "Content-Type: application/json" -d '{"tabla":"ASSET","valor":"ESTA","valor2":"","valor3":"","descripcion":"<ESTA_ID>","empr_id":"<EMPR_ID>"}'
+```
+
+**Verificación** — leer la config como la va a leer asset (`getTablaValorXEmp`):
+
+```bash
+curl -s http://10.142.0.13:8280/services/COREDataService/tabla/ASSET/valor/DEPO/empresa/<EMPR_ID>
+curl -s http://10.142.0.13:8280/services/COREDataService/tabla/ASSET/valor/PANO/empresa/<EMPR_ID>
+```
+
+Cada uno debe devolver el id guardado en `descripcion`.
+
+> La clave `ASSET` + `DEPO`/`PANO`/`ESTA` es la convención que asume F3. Si se cambia acá, cambiarla también en el código de F3.
+
+---
+
+## Paso 7 — Catálogo inicial (artículos y herramientas)
+
+Solo si el cliente ya tenía datos de catálogo en asset. Para **Caleras San Juan** (`id_empresa=1` en assetv2): 32 artículos y 2 herramientas (conteo del 2026-08-12).
+
+**7a. Extraer lo que hay en asset — dónde: terminal con `mysql` contra assetv2 del ambiente:**
+
+```sql
+SELECT artId, artBarCode, artDescription, artCoste, punto_pedido, unidadmedida FROM articles WHERE id_empresa = <ID_ASSET> AND artEstado != 'AN';
+SELECT herrId, herrcodigo, herrmarca, herrdescrip FROM herramientas WHERE id_empresa = <ID_ASSET> AND equip_estad != 'AN';
+```
+
+**7b. Cargar artículos — dónde: app de tools con un usuario de la empresa → módulo Almacenes → Artículos** (controller `traz-comp-almacenes/Articulo.php`). Carga manual, uno por uno — además de cargar datos, valida que las pantallas funcionan para esta empresa.
+
+**7c. Cargar herramientas — dónde: app de tools → módulo Pañol → Herramientas** (controller `traz-comp-pan/Herramienta.php`), asignándolas al pañol del paso 5.
+
+> ⚠️ La marca de la herramienta en tools es una referencia a `core.tablas` (no texto libre como en asset, donde además marca y modelo viajan mezclados — ej. `'Escalera 7 peldaño - Ayinco'`). Cargar por pantalla resuelve esto: la pantalla ofrece las marcas existentes y el desdoblamiento marca/modelo se decide a ojo en el momento.
+
+**Verificación** (curl):
+
+```bash
+curl -s http://10.142.0.13:8280/services/ALMDataService/articulos/<EMPR_ID>
+curl -s http://10.142.0.13:8280/services/PANDataservice/herramientas/empresa/<EMPR_ID>
+```
+
+Los conteos deben coincidir con lo extraído en 7a (menos lo que se haya decidido no migrar).
+
+> Las referencias históricas de asset (ej. las 10 filas de `tbl_otherramientas` de Caleras que apuntan a `herrId` viejos) NO se tocan en el setup — su tratamiento se define en F4.
+
+---
+
+## Paso 8 — Verificación final end-to-end
+
+1. **Lookup**: `curl .../COREDataService/empresa/porAssetId/<ID_ASSET>` → devuelve `EMPR_ID`. ✅
+2. **Config**: los 3 curls del paso 6 devuelven `DEPO_ID`, `PANO_ID`, `ESTA_ID`. ✅
+3. **Catálogo**: los 2 curls del paso 7 listan lo cargado. ✅
+4. **Aislamiento** (importante): repetir el curl de artículos con el `EMPR_ID` de OTRA empresa — no debe incluir nada de esta. ✅
+5. **Pantallas**: login en tools con un usuario del cliente → ve sus artículos en Almacenes y sus herramientas en Pañol. ✅
+
+## Registro de clientes configurados
+
+Completar una fila por cliente al terminar (este archivo se actualiza por PR, como todo):
+
+| Fecha | Empresa | `ID_ASSET` | `EMPR_ID` | `ESTA_ID` | `DEPO_ID` | `PANO_ID` | Catálogo cargado | Quién |
+|---|---|---|---|---|---|---|---|---|
+| | | | | | | | | |


### PR DESCRIPTION
## Qué cambia

Fase **F3**: el núcleo de asset deja de leer su catálogo local de almacén (`articles`) y consume el de tools vía REST, y las opciones de menú de almacén quedan inhabilitables sin borrar nada.

- **`application/helpers/tools_helper.php` (nuevo)**: `tools_empr_id()` — traduce el `id_empresa` de asset al `empr_id` de tools con el lookup `porAssetId` de F1, cacheado en sesión; `tools_config()` — lee `DEPO`/`PANO`/`ESTA` del setup del cliente (clave `ASSET` en `core.tablas`, F2); `tools_articulos()` — catálogo con cache por request y manejo del quirk del DataService (objeto en vez de lista con una sola fila); `tools_merge_articulos()` — completa el detalle local con los datos remotos. Si la empresa no está vinculada: log de error explícito + vacío (error de configuración, no estado normal).
- **9 lectores de `articles` → REST, conservando el shape de salida** (las vistas no se tocan): `getinsumo` (autocomplete value/codigo/label), `traerinsumo` (artículo por id), y los 7 getters gemelos `getXInsumos` de Preventivos, Predictivos, Backlogs, Otrabajos (×2) y Calendarios (×3). El detalle `tbl_*insumos` **sigue en MariaDB** — solo el catálogo va a tools. De paso, cada getter pasó de 21 líneas con join a 8 sin duplicación.
- **Menú**: `Groups::mnuAll()` ahora filtra `sismenu.estado = 'AC'` (la columna existía pero **nadie la consultaba** — la visibilidad la daban solo los permisos por grupo) + guarda para padres inhabilitados. `database/scripts/f3-inhabilitar-menu-almacen.sql` pone en `IN` los 11 ítems de almacén (Almacenes + hijos, Compras + hijos, Administrar Ordenes, ABM Deposito/Plantilla Insumos/Proveedor, Rep articulos pedidos), con verificación previa/posterior y reversa. **Pañol NO se toca** (F4).
- Constantes `REST_TOOLS_*` derivadas de `HOST` (hoy es el mismo EI; si tools se muda, se ajusta un solo define).

## Por qué

Fase F3 del plan (decisiones D2/D5): requiere F1 mergeada (traz-tools #426 ✅). Es el primer código de asset que cruza a tools.

## Hallazgo del relevamiento

**assetv2 tiene un espejo local completo de las tablas `alm_*` de tools** (port embebido del módulo de almacenes corriendo contra MariaDB): `alm_articulos`, `alm_pedidos_materiales` (107 filas), etc. Todos los pedidos son de empresas de prueba y el último es de 2024-05 — el supuesto D2 ("ningún cliente activo usa almacenes") **se sostiene**, pero la verificación original no había mirado estas tablas. El espejo se abandona en F5 (el flujo de pedidos pasa a tools). Registrado en STATE.

## Fuera de alcance (documentado, no silencioso)

- `agregar_insumo` (alta on-the-fly desde el form de preventivo): **ya estaba rota en producción** — el controller llama a `$this->Equipos->agregar_insumo()` sin cargar el model (fatal, bug T10 del relevamiento). El alta de artículos pasa a las pantallas de tools por definición del requerimiento (punto 5).
- `Otrabajos::getdatos` (join a `tbl_detanotapedido`, flujo muerto con 0 filas), `Ordenservicios::getInsumosPorOT`/`getArticulos`/`getDepositos` (leen el espejo `alm_*` local → **F5**, con el flujo de pedidos), `getHerramientasB`/`getProductos` (**F4**).

## Cómo lo verifiqué

- `php -l` en verde sobre los 8 archivos tocados y el helper nuevo.
- Shapes REST contrastados contra los `.dbs` post-F1 (`getArticulos2`, `porAssetId`, `getTablaValorXEmp`) — incluidos los nombres exactos de campos que devuelve cada resource.
- Contrato de salida de cada función preservado (claves `artId`/`artBarCode`/`artDescription`/`id_empresa`/`cantidad`, objetos `value`/`codigo`/`label`) verificado contra los callers reales (`Preventivo::getinsumo`, vistas de planes/OTs).
- Ítems de menú relevados contra la base de DEV (ids y slugs reales en el script, con SELECT de verificación previa porque los ids pueden diferir por ambiente).
- ⚠️ **Smoke de runtime pendiente**: el EI de DEV sigue sirviendo los `.dbs` viejos (verificado: `porAssetId` da "Operation not found"). Hace falta redeployar `ALMDataService.dbs` y `COREDataService.dbs` de `traz-tools/_backend/api/dataservice/` en el EI de DEV — está como próxima acción en STATE.

## Orden de despliegue

1. Redeploy de los `.dbs` de F1 en el EI del ambiente.
2. Deploy del código de este PR.
3. Correr `database/scripts/f3-inhabilitar-menu-almacen.sql` (el filtro de estado sin el script no cambia nada; el script sin el código tampoco — son independientes y reversibles).
4. Setup del cliente (F2) si no se hizo.

La rama encadena sobre la de F2 (#324): mergear #324 primero deja este PR solo con F3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4EqTGKc2PV4we7mX3w8s